### PR TITLE
[FIX] account_journal_security: Rules aml to do not use related fields.

### DIFF
--- a/account_journal_security/__manifest__.py
+++ b/account_journal_security/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Journal Security',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Accounting',
     'sequence': 14,
     'summary': 'Restrict the use of certain journals to certain users',

--- a/account_journal_security/security/journal_security_security.xml
+++ b/account_journal_security/security/journal_security_security.xml
@@ -28,7 +28,8 @@
         <field name="name">Account Move Line of Jornals modifiable by users</field>
         <field name="model_id" ref="account.model_account_move_line"/>
         <field name="perm_read" eval="False"/>
-        <field name="domain_force">['|', ('journal_id.modification_user_ids', '=' ,False), ('journal_id.id', 'in', user.modification_journal_ids.ids)]</field>
+        <field name="domain_force">['|', ('move_id.journal_id.modification_user_ids', '=' ,False), ('move_id.journal_id.id', 'in', user.modification_journal_ids.ids)]</field>
+        <!-- OJO: Parace que no esta manejando correctamente los campos related en las reglas, El campo aml.journal_id es related stored pero por alguna razon no esta funcionando en la regla no se calcula bien. usando el campo aml.move_id.journal_id soluciona el problema por ahora -->
     </record>
 
     <record model="ir.rule" id="journal_security_mod_rule_account_payment">
@@ -61,7 +62,8 @@
     <record model="ir.rule" id="journal_security_rule_account_move_line">
         <field name="name">Account Move Line of Jornals restricted to user</field>
         <field name="model_id" ref="account.model_account_move_line"/>
-        <field name="domain_force">['|', ('journal_id.user_ids', '=' ,False), ('journal_id.id', 'in', user.journal_ids.ids)]</field>
+        <field name="domain_force">['|', ('move_id.journal_id.user_ids', '=' ,False), ('move_id.journal_id.id', 'in', user.journal_ids.ids)]</field>
+        <!-- OJO: Parace que no esta manejando correctamente los campos related en las reglas, El campo aml.journal_id es related stored pero por alguna razon no esta funcionando en la regla no se calcula bien. usando el campo aml.move_id.journal_id soluciona el problema por ahora -->
     </record>
 
     <record model="ir.rule" id="journal_security_rule_account_payment">


### PR DESCRIPTION
aml.journal_id is a stored but related field and is not working in rule.
change it o aml.move_id.journal_id fix the problem