### PR TITLE
[12.0] base_currency_inverse_rate Make module installable

### DIFF
--- a/base_currency_inverse_rate/__manifest__.py
+++ b/base_currency_inverse_rate/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Base Currency Inverse Rate',
-    'version': '11.0.1.0.0',
+    'version': '12.0.1.0.0',
     'category': 'Accounting',
     'sequence': 14,
     'author': 'ADHOC SA',
@@ -39,7 +39,7 @@
     ],
     'test': [
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }


### PR DESCRIPTION
The module is working fine without modification on v12.0 - tested and working fine.