### PR TITLE
[IMP] display_name of account.invoice

### DIFF
--- a/account_document/__manifest__.py
+++ b/account_document/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Accounting Documents Management",
-    "version": "11.0.1.4.2",
+    "version": "11.0.1.5.0",
     "author": "Moldeo Interactive,ADHOC SA",
     "license": "AGPL-3",
     "category": "Accounting",

--- a/account_document/models/account_invoice.py
+++ b/account_document/models/account_invoice.py
@@ -174,19 +174,12 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def name_get(self):
-        TYPES = {
-            'out_invoice': _('Invoice'),
-            'in_invoice': _('Vendor Bill'),
-            'out_refund': _('Refund'),
-            'in_refund': _('Vendor Refund'),
-        }
         result = []
         for inv in self:
             result.append((
                 inv.id,
                 "%s %s" % (
-                    inv.display_name or TYPES[inv.type],
-                    inv.name or '')))
+                    inv.display_name, inv.name or '')))
         return result
 
     @api.model
@@ -237,13 +230,19 @@ class AccountInvoice(models.Model):
         # mostrar igual si existe el numero, por ejemplo si es factura de
         # proveedor
         # if self.document_number and self.document_type_id and self.move_name:
+        TYPES = {
+            'out_invoice': _('Invoice'),
+            'in_invoice': _('Vendor Bill'),
+            'out_refund': _('Credit Note'),
+            'in_refund': _('Vendor Credit note'),
+        }
         for rec in self:
             if rec.document_number and rec.document_type_id:
                 display_name = ("%s%s" % (
                     rec.document_type_id.doc_code_prefix or '',
                     rec.document_number))
             else:
-                display_name = rec.move_name
+                display_name = rec.move_name or TYPES[rec.type]
             rec.display_name = display_name
 
     @api.multi


### PR DESCRIPTION
Previous to this commit, if you have a m2o to a draft invoice, you didn't see anything as the display name was empty.
On draft invoices the form view is repeating the word invoice but it's not a big deal and it also is going to change on v13