### PR TITLE
[FIX] account_debt_management: Changes in cancel debt

### DIFF
--- a/account_debt_management/__manifest__.py
+++ b/account_debt_management/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Debt Management',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Account Reporting',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',

--- a/account_debt_management/report/account_debt_line.py
+++ b/account_debt_management/report/account_debt_line.py
@@ -428,14 +428,16 @@ class AccountDebtLine(models.Model):
                     'No se puede cancelar el resisual en moneda porque el '
                     'apunte %s aún tiene saldo contable.' % aml.id))
 
-            partial_rec = aml.credit and aml.matched_debit_ids[0] or \
-                aml.matched_credit_ids[0]
+            partial_rec = (aml.credit and aml.matched_debit_ids) \
+                and aml.matched_debit_ids[0] or aml.matched_credit_ids\
+                and aml.matched_credit_ids[0] or False
 
             exchange_move = self.env['account.move'].create(
                 self.env['account.full.reconcile']._prepare_exchange_diff_move(
                     move_date=aml.date, company=aml.company_id))
-            partial_rec.with_context(
-                skip_full_reconcile_check=True).create_exchange_rate_entry(
+            if partial_rec:
+                partial_rec.with_context(
+                    skip_full_reconcile_check=True).create_exchange_rate_entry(
                     aml, exchange_move)
             exchange_move.post()
 

--- a/account_debt_management/report/account_debt_line.py
+++ b/account_debt_management/report/account_debt_line.py
@@ -436,8 +436,7 @@ class AccountDebtLine(models.Model):
                     move_date=aml.date, company=aml.company_id))
             partial_rec.with_context(
                 skip_full_reconcile_check=True).create_exchange_rate_entry(
-                    aml, 0.0, aml.amount_residual_currency,
-                    aml.currency_id, exchange_move)
+                    aml, exchange_move)
             exchange_move.post()
 
             # verificamos que se haya conciliado correctamente

--- a/account_debt_management/report/account_debt_line_view.xml
+++ b/account_debt_management/report/account_debt_line_view.xml
@@ -45,8 +45,6 @@
                 <!-- <field name="balance" invisible="not context.get('show_balance', False)"/> -->
                 <field name="amount_currency" groups="base.group_multi_currency"/>
                 <field name="amount_residual_currency" groups="base.group_multi_currency"/>
-                <!-- usamos grupo "account.group_account_manager" para restringir y no agregamos base.group_multi_currency ya que si no hay multicurrency entonces no debería haber residual en currency y nunca debería verse -->
-                <button name="cancel_amount_residual_currency" icon="fa-ban" type="object" groups="account.group_account_manager" attrs="{'invisible': ['|', ('amount_residual_currency', '=', 0.0), ('amount_residual', '!=', 0.0)]}" confirm="Are you sure this debt is not real? This will create a journal entry on rate exchange journal to cancel this residual amount" string="Cancel residual amount on secondary currency"/>
                 <field name="financial_amount_residual" sum="Total" groups="account_financial_amount.account_use_financial_amounts"/>
                 <!-- no queremos mostrarlo mas, es util? -->
                 <!-- <field name="financial_amount" sum="Total" groups="account_financial_amount.account_use_financial_amounts"/> -->
@@ -56,6 +54,19 @@
                 <field name="company_currency_id" invisible="1"/>
             </tree>
          </field>
+    </record>
+
+    <record id="view_account_debt_line_tree2" model="ir.ui.view">
+        <field name="name">account.debt.line.tree2</field>
+        <field name="model">account.debt.line</field>
+        <field name="inherit_id" ref="view_account_debt_line_tree"/>
+        <field name="groups_id" eval="[(4, ref('account.group_account_manager'))]"/>
+        <field name="arch" type="xml">
+            <field name="amount_residual_currency" position="after">
+                <!-- usamos grupo "account.group_account_manager" para restringir y no agregamos base.group_multi_currency ya que si no hay multicurrency entonces no debería haber residual en currency y nunca debería verse -->
+                <button name="cancel_amount_residual_currency" icon="fa-ban" type="object" groups="base.group_no_one" attrs="{'invisible': ['|', ('amount_residual_currency', '=', 0.0), ('amount_residual', '!=', 0.0)]}" confirm="Are you sure this debt is not real? This will create a journal entry on rate exchange journal to cancel this residual amount" string="Cancel residual amount on secondary currency"/>
+            </field>
+        </field>
     </record>
 
     <record id="view_account_debt_line_form" model="ir.ui.view">


### PR DESCRIPTION
The original method "create_exchange_rate_entry" in odoo has change, now it's no necesary pass some argument.

Ticket 21361