### PR TITLE
[FIX] account_document: revert change that cause error

### DIFF
--- a/account_document/models/account_move_line.py
+++ b/account_document/models/account_move_line.py
@@ -41,12 +41,12 @@ class AccountMoveLine(models.Model):
         return res
 
     @api.model
-    def domain_move_lines_for_reconciliation(self, _str):
+    def domain_move_lines_for_reconciliation(self, str):
         """ Add move display name in search of move lines"""
         _super = super(AccountMoveLine, self)
         _get_domain = _super.domain_move_lines_for_reconciliation
-        domain = _get_domain(_str)
-        if not _str and _str != '/':
+        domain = _get_domain(str)
+        if not str and str != '/':
             return domain
-        domain_trans_ref = [('move_id.display_name', 'ilike', _str)]
+        domain_trans_ref = [('move_id.display_name', 'ilike', str)]
         return expression.OR([domain, domain_trans_ref])


### PR DESCRIPTION
Currently Odoo server is throwing an error that do not let to select a
contrapart in the conciliation widget.

This is was cause becase the method firm was change in order to try to
overwrite the str type, but some reasons this fails.

I think is because is not a regular inherit and need to have the same
name of the arguments.