### PR TITLE
[FIX] account_document: move.line methods are now in new model

### DIFF
--- a/account_document/models/__init__.py
+++ b/account_document/models/__init__.py
@@ -9,3 +9,4 @@ from . import res_company
 from . import account_chart_template
 from . import account_payment_receiptbook
 from . import account_payment
+from . import account_reconciliation_widget

--- a/account_document/models/account_move_line.py
+++ b/account_document/models/account_move_line.py
@@ -1,13 +1,7 @@
-from odoo import models, api, fields
-# from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo import models, fields
 
 
 class AccountMoveLine(models.Model):
-    """
-    Show and allow to search by move display name (Document number) on
-    bank statements and partner debt reconcile
-    """
 
     _inherit = 'account.move.line'
 
@@ -19,32 +13,3 @@ class AccountMoveLine(models.Model):
         store=True,
         index=True,
     )
-
-    @api.multi
-    def _prepare_move_lines(
-            self, move_lines, target_currency=False, target_date=False,
-            recs_count=0):
-        res = super(
-            AccountMoveLine,
-            self).prepare_move_lines_for_reconciliation_widget(
-            move_lines, target_currency=target_currency,
-            target_date=target_date, recs_count=recs_count)
-        for rec in res:
-            line = self.browse(rec['id'])
-            display_name = line.move_id.display_name or ''
-            rec['name'] = (
-                line.name and line.name != '/' and
-                display_name + ': ' + line.name or
-                display_name)
-        return res
-
-    @api.model
-    def _domain_move_lines(self, search_str):
-        """ Add move display name in search of move lines"""
-        _super = super(AccountMoveLine, self)
-        _get_domain = _super._domain_move_lines
-        domain = _get_domain(search_str)
-        if not search_str and search_str != '/':
-            return domain
-        domain_trans_ref = [('move_id.display_name', 'ilike', search_str)]
-        return expression.OR([domain, domain_trans_ref])

--- a/account_document/models/account_reconciliation_widget.py
+++ b/account_document/models/account_reconciliation_widget.py
@@ -1,0 +1,32 @@
+from odoo import models, api, fields
+from odoo.osv import expression
+
+
+class AccountReconciliation(models.AbstractModel):
+
+    _inherit = 'account.reconciliation.widget'
+
+    @api.multi
+    def _prepare_move_lines(self, move_lines, target_currency=False, target_date=False, recs_count=0):
+        """ Show and allow to search by move display name (Document number) on bank statements and partner debt
+        reconcile """
+        res = super()._prepare_move_lines(
+            move_lines, target_currency=target_currency, target_date=target_date, recs_count=recs_count)
+
+        for rec in res:
+            line = self.env['account.move.line'].browse(rec['id'])
+            display_name = line.move_id.display_name or ''
+            rec['name'] = line.name and line.name != '/' and display_name + ': ' + line.name or display_name
+        return res
+
+    @api.model
+    def _domain_move_lines(self, search_str):
+        """ Add move display name in search of move lines"""
+        _super = super()
+        _get_domain = _super._domain_move_lines
+        domain = _get_domain(search_str)
+        if not search_str and search_str != '/':
+            return domain
+        domain_trans_ref = [('move_id.display_name', 'ilike', search_str)]
+        return expression.OR([domain, domain_trans_ref])
+


### PR DESCRIPTION
ticket 21957

Some methods that use to be in account.move.line model now change and belongs to account reconciliation widget.