### PR TITLE
[13.0] [REL] First release in v13: account_statement_move_import

### DIFF
--- a/account_statement_move_import/__manifest__.py
+++ b/account_statement_move_import/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Statement Move Import',
-    'version': '12.0.1.0.0',
+    'version': '13.0.1.0.0',
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',
@@ -37,9 +37,7 @@
     ],
     'demo': [
     ],
-    'test': [
-    ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }

--- a/account_statement_move_import/wizard/__init__.py
+++ b/account_statement_move_import/wizard/__init__.py
@@ -1,2 +1,5 @@
-# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
 from . import account_statement_move_import_wizard


### PR DESCRIPTION
[FIX] Update manifest and remove old comment statements
[FIX] remove the method to compute default and setted in the field using lambda
[FIX] remove the convert string to date, now is datetime by defaults
[FIX] remove multi from the methods
[FIX] use the shortest form to call super