### PR TITLE
[FIX] Add try except block on invoice validation

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -198,7 +198,12 @@ class ResCompanyInterest(models.Model):
             # update amounts for new invoice
             invoice.compute_taxes()
             if self.automatic_validation:
-                invoice.action_invoice_open()
+                try:
+                    invoice.action_invoice_open()
+                except Exception as e:
+                    _logger.error(
+                        "Something went wrong "
+                        "creating interests invoice: {}".format(e))
 
     @api.multi
     def prepare_info(self, to_date_format, debt):


### PR DESCRIPTION
* Prevents stopping CRON task whenever something goes wrong.
* Invoices that can't be validated remain in draft.