### PR TITLE
[FIX] account_ux: don't block some purchases

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -154,9 +154,7 @@ class AccountMove(models.Model):
         """ Only let to create customer invoices/vendor bills in respective sale/purchase journals """
         error = self.filtered(
             lambda x: x.is_sale_document() and x.journal_id.type != 'sale' or
-            not x.is_sale_document() and x.journal_id.type == 'sale' or
-            x.is_purchase_document() and x.journal_id.type != 'purchase' or
-            not x.is_purchase_document() and x.journal_id.type == 'purchase')
+            x.is_purchase_document() and x.journal_id.type != 'purchase')
         if error:
             raise ValidationError(_(
                 'You can create sales/purchase invoices exclusively in the respective sales/purchase journals'))


### PR DESCRIPTION
Allow entries on sales/purchase journals. This is mainly for expenses that creates a journal entry on a purchase journal and before this fix it was not possible