### PR TITLE
[12.0] [FIX] account_interests: Loop in the compute method to avoid singleton error

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -274,4 +274,5 @@ class ResCompanyInterest(models.Model):
 
     @api.depends('domain')
     def _compute_has_domain(self):
-        self.has_domain = len(safe_eval(self.domain)) > 0
+        for rec in self:
+            rec.has_domain = len(safe_eval(rec.domain)) > 0


### PR DESCRIPTION
**Ticket 33286**