### PR TITLE
[IMP] inverse_rate: use 6 digits

### DIFF
--- a/base_currency_inverse_rate/models/res_currency_rate.py
+++ b/base_currency_inverse_rate/models/res_currency_rate.py
@@ -9,7 +9,7 @@ class ResCurrencyRate(models.Model):
     _inherit = "res.currency.rate"
 
     inverse_rate = fields.Float(
-        'Inverse Rate', digits=(12, 4),
+        'Inverse Rate', digits=(12, 6),
         compute='_compute_inverse_rate',
         inverse='_inverse_inverse_rate',
         help='The rate of the currency from the currency of rate 1',


### PR DESCRIPTION
at least 6 digits are needed on some currencies