### PR TITLE
[13.0] [FIX] account_ux: Fix a bug with commercial of invoices, when change partner in the invoice.

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -89,7 +89,7 @@ class AccountMove(models.Model):
     @api.onchange('partner_id')
     def _onchange_partner_commercial(self):
         if self.partner_id.user_id:
-            self.user_id = self.partner_id.user_id.id
+            self.invoice_user_id = self.partner_id.user_id.id
 
     def copy(self, default=None):
         res = super().copy(default=default)


### PR DESCRIPTION
Use invoice_user_id field instead user_id this last one it's related non-stored field