### PR TITLE
[IMP] account_document: remove number from order

### DIFF
--- a/account_document/models/account_invoice.py
+++ b/account_document/models/account_invoice.py
@@ -26,7 +26,7 @@ class AccountInvoice(models.Model):
     field and also overwriting name_get to use it
     """
     _inherit = "account.invoice"
-    _order = "date_invoice desc, document_number desc, number desc, id desc"
+    _order = "date_invoice desc, document_number desc, id desc"
     # _order = "document_number desc, number desc, id desc"
 
     report_amount_untaxed = fields.Monetary(


### PR DESCRIPTION
remove number from order on account.invoices as it's not used so much and, as it's not indexed, it can lead on performance issues.