### PR TITLE
[FIX] account_ux: default taxes per company

### DIFF
--- a/account_ux/wizards/res_config_settings.py
+++ b/account_ux/wizards/res_config_settings.py
@@ -59,3 +59,8 @@ class ResConfigSettings(models.TransientModel):
             "supplier_taxes_id",
             self.purchase_tax_ids.ids,
             company_id=self.company_id.id)
+
+        sale_taxes = self.sale_tax_ids.filtered(lambda tax: tax.company_id == self.company_id)
+        purchase_taxes = self.purchase_tax_ids.filtered(lambda tax: tax.company_id == self.company_id)
+        self.company_id.account_sale_tax_id = sale_taxes[0] if sale_taxes else sale_taxes
+        self.company_id.account_purchase_tax_id = purchase_taxes[0] if purchase_taxes else purchase_taxes


### PR DESCRIPTION
If you set default taxes in accounting configuration, then when you
create an invoice and add a new line the tax column will be filled with
the default tax.# Por favor ingresa el mensaje del commit para tus
cambios.