### PR TITLE
[IMP]account_debt_report: security

### DIFF
--- a/account_debt_report/README.rst
+++ b/account_debt_report/README.rst
@@ -15,21 +15,10 @@
 Account Debt Management
 =======================
 
-It adds new ways to see partner debt:
+It adds new report to see partner debt:
 
-* Two new tabs (customer debt / supplier debt) on partner form showing the detail of all unreconciled lines with amount on currencies and cumulative amounts
-* New button from partner to display all the history for a partner
-* Add partner balance
+* IMPORTANT: for users without invoicing rights, we still allow to get the receivable debt report for any customer (not only the ones for the user)
 * You can send email to one or multiple partners with they debt report
-
-By default all lines of same document are grouped and minimun maturity date of the move line is shown, you can change this behaviur by:
-#. Create / modify parameter "account_debt_management.date_maturity_type" with one of the following values:
-
-    #. detail: lines will be splitted by maturity date
-    #. max: one line per document, max maturity date shown
-    #. min (default value if no parameter or no matching): one line per document, min maturity date shown.
-
-IMPORTANT: this modules isn't compatible with account_journal_security or account_multi_store module. This mudule allows user to see all debt lines no matter journals restrictions
 
 Installation
 ============

--- a/account_debt_report/__manifest__.py
+++ b/account_debt_report/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Debt Report',
-    'version': '13.0.1.0.0',
+    'version': '13.0.1.1.0',
     'category': 'Account Reporting',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',

--- a/account_debt_report/models/res_partner.py
+++ b/account_debt_report/models/res_partner.py
@@ -94,7 +94,7 @@ class ResPartner(models.Model):
 
         if from_date:
             initial_domain = domain + [('date', '<', from_date)]
-            balance = self.env['account.move.line'].read_group(
+            balance = self.env['account.move.line'].sudo().read_group(
                 initial_domain, fields=['balance'], groupby=['partner_id'])[0]['balance']
             res = [get_line_vals(name=_('INITIAL BALANCE'), balance=balance)]
             domain.append(('date', '>=', from_date))
@@ -108,7 +108,7 @@ class ResPartner(models.Model):
         else:
             final_line = []
 
-        records = self.env['account.move.line'].search(domain, order='date asc, date_maturity asc, name, id')
+        records = self.env['account.move.line'].sudo().search(domain, order='date asc, date_maturity asc, name, id')
 
         # construimos una nueva lista con los valores que queremos y de
         # manera mas facil

--- a/account_debt_report/wizard/account_debt_report_wizard.py
+++ b/account_debt_report/wizard/account_debt_report_wizard.py
@@ -10,27 +10,22 @@ class AccountDebtReportWizard(models.TransientModel):
     _name = 'account.debt.report.wizard'
     _description = 'Account Debt Report Wizard'
 
+    def _default_result_selection(self):
+        return 'all' if self.env.user.has_group('account.group_account_invoice') else 'receivable'
+
     company_id = fields.Many2one(
         'res.company',
         'Company',
         help="If you don't select a company, debt for all companies will be "
         "exported."
     )
-    # TODO si nadie reclama esta opcion la depreciamos y simplidicamos reporte
-    # si simplificamos podemos tomar logica de reporte de bid ar
-    # company_type = fields.Selection([
-    #     ('group_by_company', 'Group by Company'),
-    #     ('consolidate', 'Consolidate all Companies'),
-    # ],
-    #     default='group_by_company',
-    # )
     result_selection = fields.Selection(
         [('receivable', 'Receivable Accounts'),
          ('payable', 'Payable Accounts'),
          ('all', 'Receivable and Payable Accounts')],
         "Account Type's",
         required=True,
-        default='all'
+        default=_default_result_selection,
     )
     from_date = fields.Date('From')
     to_date = fields.Date('To')

--- a/account_debt_report/wizard/account_debt_report_wizard_view.xml
+++ b/account_debt_report/wizard/account_debt_report_wizard_view.xml
@@ -7,7 +7,7 @@
             <form>
                 <group>
                     <group>
-                        <field name="result_selection"/>
+                        <field name="result_selection" groups="account.group_account_invoice"/>
                         <field name="company_id" string="Company" ref="base.main_company"/>
                         <!-- TODO si nadie reclama esta opcion la depreciamos y simplificamos reporte -->
                         <!-- <field name="company_type" attrs="{'required': [('company_id', '=', False)], 'invisible': [('company_id', '!=', False)]}" ref="base.main_company"/> -->


### PR DESCRIPTION
1. para usuarios sin permiso facturacion permitimos solo imprimir el reporte de deuda de clientes
2. para que justamente ande usamos sudo a la hora de consultar los move.line