### PR TITLE
[FIX]account_ux: compute currency rate

### DIFF
--- a/account_ux/wizards/account_change_currency.py
+++ b/account_ux/wizards/account_change_currency.py
@@ -52,7 +52,7 @@ class AccountChangeCurrency(models.TransientModel):
                 )
             self.currency_rate = currency._convert(
                 1.0, self.currency_to_id, self.move_id.company_id,
-                date=self.move_id.date or
+                date=self.move_id["date" if self.move_id.is_purchase_document() else "invoice_date"] or
                 fields.Date.context_today(self))
 
     def change_currency(self):


### PR DESCRIPTION
The calculation of the quote depends on the date of the invoice, however this date must be different for the type of invoice:

If it is a customer invoice we should take invoice_date
If it is a supplier invoice we should take date (accounting date).
This change was necessary because we get the following case: in the case of customer invoices, if we take the date field, what it will do is calculate the quote with the date on which the invoice was created. And this is a problem because if the user creates them before and validates them some time later, they will always take into account an old quote, taking into account that the date field is not shown in customer invoices and therefore they cannot edit.