### PR TITLE
[ADD] account_ux: Debit note in move form view.

### DIFF
--- a/account_ux/README.rst
+++ b/account_ux/README.rst
@@ -69,6 +69,7 @@ Several Improvements to accounting:
 #. Add constraint invoice-journal-type to let the user create sales/purchase invoices exclusively in the respectives sales/purchase journals:
 #. Add amount_total and amount_untaxed in the invoice tree view as optional and hide fields
 #. Add new filter 'Without resiual' on partner ledger
+#. Make Debit Note Origin field visible and editable by the user in the account.move form view. This will help to link new debit notes with the original invoice when this ones were not created from invoices "Add Debit Note" action button directly.
 
 Installation
 ============

--- a/account_ux/__manifest__.py
+++ b/account_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account UX',
-    'version': "13.0.1.22.0",
+    'version': "13.0.1.23.0",
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',
@@ -32,6 +32,7 @@
         'account',
         "payment",
         "base_vat",
+        "account_debit_note",
     ],
     'data': [
         'security/account_ux_security.xml',

--- a/account_ux/views/account_move_views.xml
+++ b/account_ux/views/account_move_views.xml
@@ -70,6 +70,14 @@
                 <attribute name="groups">account.group_account_invoice</attribute>
                 <attribute name="force_save">1</attribute>
             </field>
+
+            <!-- permitimos modificar "Factura origne de la ND" para poder vincular ND creadas a mano -->
+            <xpath expr="//group[@name='sale_info_group']/field[@name='debit_origin_id']" position="attributes">
+                <!-- <attribute name="attrs"></attribute> -->
+                <attribute name="attrs">{'invisible': [('type', '!=', 'out_invoice')], 'readonly': [('state', '!=', 'draft')]}</attribute>
+                <attribute name="domain">[('type', 'in', ('out_invoice', 'out_refund')), ('partner_id.commercial_partner_id', '=', commercial_partner_id), ('state', '=', 'posted')]</attribute>
+            </xpath>
+
         </field>
     </record>
 


### PR DESCRIPTION
ticket 48753
---

Make Debit note Origin field tvisible and editable buy the user in the account.move form view.

This will help to link new debit notes with the original invoice when this ones were not created from invoices "Add Debit Note" action button directly.