### PR TITLE
[FIX] account_debt_report: group repot by payment.

### DIFF
--- a/account_debt_report/models/res_partner.py
+++ b/account_debt_report/models/res_partner.py
@@ -89,7 +89,7 @@ class ResPartner(models.Model):
                 'account_debt_report.group_payment_group_payments', 'False'))
 
         payment_groups = {}
-        group_count = 0
+        group_count = len(res)
 
         # construimos una nueva lista con los valores que queremos y de
         # manera mas facil


### PR DESCRIPTION
ticket 53861
---

This was not actually working when we have a payment that has date_maturity after the invoice date. Now, no matter the date we will create the groups properly