### PR TITLE
[IMP] account_interests: posted and not 0.0 lines

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -125,8 +125,9 @@ class ResCompanyInterest(models.Model):
         self.ensure_one()
         move_line_domain = [
             ('account_id', 'in', self.receivable_account_ids.ids),
-            ('full_reconcile_id', '=', False),
-            ('date_maturity', '<', to_date)
+            ('date_maturity', '<', to_date),
+            ('move_id.state', '=', 'posted'),
+            '|', ('full_reconcile_id', '=', False), ('reconciled', '=', False),
         ]
         return move_line_domain
 


### PR DESCRIPTION
ticket 56176
---

Only take into account the account.move.lines that have been reconciled and that are in the posted state.