### PR TITLE
[FIX] account_ux: allow action_draft on reconciled receipts

### DIFF
--- a/account_ux/models/account_bank_statement_line.py
+++ b/account_ux/models/account_bank_statement_line.py
@@ -11,15 +11,3 @@ class AccountBankStatementLine(models.Model):
     duplicated_group = fields.Char(
         readonly=True,
         help='Technical field used to store information group a possible duplicates bank statement line')
-
-    def button_cancel_reconciliation(self):
-        """ Clean move_name to allow reconciling with new line.
-        """
-        res = super().button_cancel_reconciliation()
-        self.write({'move_name': False})
-        return res
-
-    # TODO remove in version 15.0 only needed to clean up some statements with move name is set and it should not in
-    # order to be able to reconcile the line statement line in future
-    def button_fix_clean_move_name(self):
-        self.write({'move_name': False})


### PR DESCRIPTION
Ticket: 58213
Se mejora además lo siguiente: si se pasa un recibo a borrador que está conciliado con una línea del extracto entonces se marca como desconciliada también la línea del extracto y se pasa el extracto a estado 'posted' (Procesando) si es que el exctracto se encuentra validado (state == 'confirm')