### PR TITLE
[FIX] account_ux: make method _get_fiscal_position public

### DIFF
--- a/account_ux/models/__init__.py
+++ b/account_ux/models/__init__.py
@@ -11,3 +11,4 @@ from . import account_move_line
 from . import res_partner
 from . import res_currency_rate
 from . import account_move
+from . import account_fiscal_position

--- a/account_ux/models/account_fiscal_position.py
+++ b/account_ux/models/account_fiscal_position.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = 'account.fiscal.position'
+
+    def get_fiscal_position(self, partner, delivery=None):
+        return super(AccountFiscalPosition, self)._get_fiscal_position(partner, delivery=delivery)

--- a/account_ux/models/account_fiscal_position.py
+++ b/account_ux/models/account_fiscal_position.py
@@ -4,5 +4,8 @@ from odoo import models
 class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
 
-    def get_fiscal_position(self, partner, delivery=None):
+    def get_fiscal_position(self, partner_id, delivery_id=None):
+        PartnerObj = self.env['res.partner']
+        partner = PartnerObj.browse(partner_id)
+        delivery = PartnerObj.browse(delivery_id) if delivery_id else None
         return super(AccountFiscalPosition, self)._get_fiscal_position(partner, delivery=delivery)


### PR DESCRIPTION
We implement this fix in order to be able to have access to method _get_fiscal_position by API