### PR TITLE
[FIX] account_ux: forced currency rate on invoice

### DIFF
--- a/account_ux/wizards/account_change_currency.py
+++ b/account_ux/wizards/account_change_currency.py
@@ -64,11 +64,11 @@ class AccountChangeCurrency(models.TransientModel):
             self.currency_rate)
 
         move = self.move_id.with_context(check_move_validity=False)
+        move.currency_id = self.currency_to_id.id
         for line in move.line_ids:
             # do not round on currency digits, it is rounded automatically
             # on price_unit precision
             line.price_unit = line.price_unit * self.currency_rate
-        move.currency_id = self.currency_to_id.id
 
         self.move_id.message_post(body=message)
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
Ticket: 59842
Al forzar la moneda en factura no se toma esa cotización y al volver a la moneda anterior se actualizan incorrectamente los importes de las líneas.