### PR TITLE
[FIX] account_interests: change domain

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -127,7 +127,7 @@ class ResCompanyInterest(models.Model):
             ('account_id', 'in', self.receivable_account_ids.ids),
             ('full_reconcile_id', '=', False),
             ('date_maturity', '<', to_date),
-            ('partner.active', '=', True),
+            ('partner_id.active', '=', True),
         ]
         return move_line_domain
 


### PR DESCRIPTION
partner.active isn't a field and causes an error, partner_id.active is the correct form