### PR TITLE
[FIX] account_interests: not able to create debit note

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -133,10 +133,6 @@ class ResCompanyInterest(models.Model):
     def create_invoices(self, to_date, groupby='partner_id'):
         self.ensure_one()
 
-        journal = self.env['account.journal'].search([
-            ('type', '=', 'sale'),
-            ('company_id', '=', self.company_id.id)], limit=1)
-
         move_line_domain = self._get_move_line_domains(to_date)
 
         # Check if a filter is set
@@ -175,6 +171,14 @@ class ResCompanyInterest(models.Model):
             partner_id = line[groupby][0]
 
             partner = self.env['res.partner'].browse(partner_id)
+
+            # Necesitamos que la factura a generar se cree en un diaro compatible, simulamos crear una nota de debito
+            # para que el odoo auto calcule el diario mas recomendable y usamos ese para crear las factura de interes
+            # relacionada a cada partner
+            journal = self.env['account.move'].with_context(
+                internal_type='debit_note', default_move_type='out_invoice').new(
+                    {'partner_id': partner_id, 'move_type': 'out_invoice'}).journal_id
+
             move_vals = self._prepare_interest_invoice(
                 partner, debt, to_date, journal)
 


### PR DESCRIPTION
Crear la nota de debito en el diario de ventas compatible y sugerido por defecto en Odoo.

Antes de este cambio si teniamos por ejemplo si necesitamos generar una nota de debito de exportación daba error porque en si siempre elegiamos un tipo de diario regular de ventas que no era compatible