### PR TITLE
[ADD] account_ux: company of the accounts of lines different from the company of the invoice

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -48,6 +48,9 @@ class AccountMove(models.Model):
 
     def action_post(self):
         """ After validate invoice will sent an email to the partner if the related journal has mail_template_id set """
+        if any(line.account_id.company_id != self.company_id for line in self.line_ids):
+            raise UserError(_("There is almost one account in the journal entry of this move that belongs to a company that "
+                                  "is different to the company of the move.\n"))
         res = super().action_post()
         self.action_send_invoice_mail()
         return res


### PR DESCRIPTION
Ticket: 61691
Prevent posting moves that have lines in the journal entry with accounts belonging to companies that are different from the company of the invoice. How to reply: https://drive.google.com/file/d/1vHo9xtn_5bFcbYzTbyFDY5LFOKzQreLZ/view