### PR TITLE
[REF] account_interests: remove unused debit_note context

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -177,9 +177,7 @@ class ResCompanyInterest(models.Model):
             move_vals = self._prepare_interest_invoice(
                 partner, debt, to_date, journal)
 
-            # We send document type for compatibility with argentinian invoices
-            move = self.env['account.move'].with_context(
-                internal_type='debit_note').create(move_vals)
+            move = self.env['account.move'].create(move_vals)
 
             if self.automatic_validation:
                 try:


### PR DESCRIPTION
Este contexto ya no tiene uso y de hecho en este commit habiamos implementado lo necesario pero nos ovlidamos sacar esto https://github.com/ingadhoc/account-financial-tools/commit/38524df86e83455a390dd81c72e2da2e1ca333b0