### PR TITLE
[IMP] account_ux: set deafult taxes on products

### DIFF
--- a/account_ux/models/__init__.py
+++ b/account_ux/models/__init__.py
@@ -13,3 +13,4 @@ from . import res_company
 from . import res_currency_rate
 from . import account_move
 from . import account_bank_statement_line
+from . import chart_template

--- a/account_ux/models/chart_template.py
+++ b/account_ux/models/chart_template.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class AccountChartTemplate(models.Model):
+    _inherit = "account.chart.template"
+
+    def _load(self, company):
+        res = super()._load(company)
+        self.env['res.config.settings']._set_default_tax('sale', company.account_sale_tax_id, company)
+        self.env['res.config.settings']._set_default_tax('purchase', company.account_purchase_tax_id, company)
+        return res

--- a/account_ux/wizards/res_config_settings.py
+++ b/account_ux/wizards/res_config_settings.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from odoo import fields, models, api
+from odoo.exceptions import ValidationError
 
 
 class ResConfigSettings(models.TransientModel):
@@ -40,26 +41,38 @@ class ResConfigSettings(models.TransientModel):
             rec.purchase_tax_ids = supplier_taxes_ids
 
     def _inverse_sale_tax_ids(self):
-        ir_default = self.env['ir.default'].sudo()
-
         for rec in self:
-            ir_default.set(
-                'product.template',
-                "taxes_id",
-                rec.sale_tax_ids.ids,
-                company_id=rec.company_id.id)
-            sale_taxes = rec.sale_tax_ids.filtered(lambda tax: tax.company_id == rec.company_id)
-            rec.company_id.account_sale_tax_id = sale_taxes[0] if sale_taxes else sale_taxes
+            rec._set_default_tax('sale', rec.sale_tax_ids, rec.company_id)
 
     def _inverse_purchase_tax_ids(self):
-        ir_default = self.env['ir.default'].sudo()
-
         for rec in self:
-            ir_default.set(
-                'product.template',
-                "supplier_taxes_id",
-                rec.purchase_tax_ids.ids,
-                company_id=rec.company_id.id)
+            rec._set_default_tax('purchase', rec.purchase_tax_ids, rec.company_id)
 
-            purchase_taxes = rec.purchase_tax_ids.filtered(lambda tax: tax.company_id == rec.company_id)
-            rec.company_id.account_purchase_tax_id = purchase_taxes[0] if purchase_taxes else purchase_taxes
+    @api.model
+    def _set_default_tax(self, type_tax_use, taxes, company):
+        """ Creamos este metodo para no duplicar tanto codigo y ademas para poder llamarlo desde chart template sin
+        necesidad de instancear un res.config.settings"""
+        ir_default = self.env['ir.default'].sudo()
+        if type_tax_use == 'sale':
+            product_field = 'taxes_id'
+            company_field = 'account_sale_tax_id'
+        elif type_tax_use == 'purchase':
+            product_field = 'supplier_taxes_id'
+            company_field = 'account_purchase_tax_id'
+        else:
+            raise ValidationError('type_tax_use %s is invalid, possible values are "sale" or "purchase"')
+        ir_default.set(
+            'product.template',
+            product_field,
+            taxes.ids,
+            company_id=company.id)
+        company_taxes = taxes.filtered(lambda tax: tax.company_id == company)
+        company.write({company_field: company_taxes[:1]})
+        if company_taxes:
+            # seteamos este impuesto por defecto a todos los productos de esta compañía o que o tengan compañía y
+            # que no tengan ningun impuesto de esta compania ya configurado
+            all_company_taxes = self.env['account.tax'].search(
+                [('type_tax_use', '=', type_tax_use), ('company_id', '=', company.id)])
+            self.env['product.template'].search([
+                ('company_id', 'in', [False, company.id]),
+                (product_field, 'not in', all_company_taxes.ids)]).write({product_field: [(4, company_taxes[0].id)]})


### PR DESCRIPTION
1. al instalar el plan de cuentas, no se estaba seteando este valor por defecto de res.config, esto solo afectaba si el usuario hacia un cambio
2. si se cambiaba plan de cuentas, como se hace desde un res.config.settings y el inverse se llamaba antes de cambiar el plan, entonces quedaban seteados valores por defecto erroneos
3. mejoramos para que a los productos existentes se les asigne el impuesto por defecto (salvo que ya tengan algún otro de esta compañía)
