### PR TITLE
[FIX] account_ux: change currency when round change taxes

### DIFF
--- a/account_ux/wizards/account_change_currency.py
+++ b/account_ux/wizards/account_change_currency.py
@@ -64,12 +64,12 @@ class AccountChangeCurrency(models.TransientModel):
             self.currency_rate)
 
         move = self.move_id.with_context(check_move_validity=False)
+        move.currency_id = self.currency_to_id.id
+        move._onchange_currency()
         for line in move.line_ids:
             # do not round on currency digits, it is rounded automatically
             # on price_unit precision
             line.price_unit = line.price_unit * self.currency_rate
-        move.currency_id = self.currency_to_id.id
-        move._onchange_currency()
 
         # This is required to compute to recompute the tax lines again
         if self.currency_rate != 1:


### PR DESCRIPTION
Esto resuelve un error poco comun cuando un cambio de moneda hace que un imuesto deje de existir. Pasa por ej en chile donde no hay decimales. Entonces si se convierten importes "bajos" la línea de impuesto deja de existir pero no se recomputaba. Con esto quedaria resuelto.