### PR TITLE
[FIX] _journal_security: show inactive users on journal

### DIFF
--- a/account_journal_security/models/account_journal.py
+++ b/account_journal_security/models/account_journal.py
@@ -19,6 +19,7 @@ class AccountJournal(models.Model):
         help='If choose some users, then this journal and the information'
         ' related to it will be only visible for those users.',
         copy=False,
+        context={'active_test': False}
     )
 
     modification_user_ids = fields.Many2many(
@@ -31,6 +32,7 @@ class AccountJournal(models.Model):
         ' create, write or delete accounting data related of this journal. '
         'Information will still be visible for other users.',
         copy=False,
+        context={'active_test': False}
     )
 
     journal_restriction = fields.Selection(


### PR DESCRIPTION
Antes de esto. Si, por ej, tenía dos usuarios asignados a un journal. Archivaba uno y luego sacaba desde el journal al otro usuario. Quedaba aparentemente sin restricción (de hecho se mostraba ninguno). El tema es que de fondo seguía asignado el usuario archivado y la busqueda ('modification_user_ids', '=', False) traducida a query no termina funcionando. Porque en la tabla sigue habiendo registros vinculados a ese usuario archivado. Con este cambio sencillo se mantiene visible ese otro usuario