### PR TITLE
[FIX]account_ux: Change currency button also visible for invoicing user

### DIFF
--- a/account_ux/views/account_move_views.xml
+++ b/account_ux/views/account_move_views.xml
@@ -60,10 +60,19 @@
                 <attribute name="force_save">1</attribute>
             </field>
 
-            <field name="currency_id" position="after">
-                <button name="%(action_account_change_currency)d" type="action" attrs="{'invisible':[('state','!=','draft')]}" icon="fa-pencil" class="btn-link"/>
+            <xpath expr="//group[@id='header_right_group']/div/field[@name='currency_id']" position="after">
+                <button name="%(action_account_change_currency)d" type="action" attrs="{'invisible':[('state','!=','draft')]}" icon="fa-pencil" class="btn-link"
+                    groups="account.group_account_readonly"/>
                 <field name="other_currency" invisible="1"/>
-            </field>
+            </xpath>
+
+            <xpath expr="//group[@id='header_right_group']/field[@name='currency_id']" position="replace">
+                <label for="currency_id" groups="!account.group_account_readonly,base.group_multi_currency"/>
+                <div groups="!account.group_account_readonly,base.group_multi_currency">
+                    <field name="currency_id" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                    <button name="%(action_account_change_currency)d" type="action" attrs="{'invisible':[('state','!=','draft')]}" icon="fa-pencil" class="btn-link"/>
+                </div>
+            </xpath>
 
             <label for="journal_id" position="attributes">
                 <attribute name="groups">account.group_account_invoice</attribute>


### PR DESCRIPTION
Before this commit, users belonging to account.group_account_invoice could not see the change currency button because they didn't have permission to view the div where it was defined, and instead would be able to see the invoice's currency_id field lower in the form, where the button was not added.

This commit defines the button twice and shows one of them to the user depending on their group permissions.

The addressed changes were introduced in
https://github.com/odoo/odoo/commit/afde2bdef47c5244041934c7ef8875e2261372cc