### PR TITLE
[REM] account_ux: move _compute_payments_widget_to_reconcile_info

### DIFF
--- a/account_ux/README.rst
+++ b/account_ux/README.rst
@@ -60,7 +60,7 @@ Configuration
 
 To configure this module, you need to:
 
-#. No configuration nedeed.
+#. To ensure the 'reconcile on company currency' option functions correctly within this module, you will need to apply this FIX from https://github.com/odoo/odoo/pull/170066/files.
 
 Usage
 =====

--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -87,39 +87,54 @@ class AccountMove(models.Model):
         res._onchange_partner_commercial()
         return res
 
-    def _compute_payments_widget_to_reconcile_info(self):
-        """
-        Modificamos el widget para que si la compañía tiene el setting de forzar concilacion en moneda y estamos
-        en esa situacion (cuenta deudora no tiene moneda). Entonces el importe que previsualizamos para conciliar
-        respeta la modificacion que hacemos al conciliar (basicamente que importa el rate en pesos por lo cual tomamos
-        el rate de la factura)
-        """
-        super()._compute_payments_widget_to_reconcile_info()
-
+    # Sobrescribe el método de odoo en el PR https://github.com/odoo/odoo/pull/170066/files
+    def get_amount_diff_foreign_currencies(self, line, move):
         def get_accounting_rate(company_currency, amount, amount_currency, currency):
             if company_currency.is_zero(amount) or currency.is_zero(amount_currency):
                 return 0.0
             else:
                 return abs(amount_currency) / abs(amount)
 
-        # TODO tal vez chequear tmb que moneda de factura sea distinta? o eso no influye? habria que ver caso de pagar con usd factura en ars
-        for move in self.filtered(
-                lambda x: x.invoice_outstanding_credits_debits_widget and \
-                x.company_id.currency_id != x.currency_id and x.company_id.reconcile_on_company_currency):
-            pay_term_lines = move.line_ids\
-                .filtered(lambda line: line.account_id.account_type in ('asset_receivable', 'liability_payable'))
-            # deberia ser solo una cuenta, pero como super hace un in chequeamos que cualquier cuenta pueda tener moneda
-            if any(x.currency_id for x in pay_term_lines.account_id):
-                continue
-            # para todos los asientos que son en moneda secundaria y que no tengan moneda calculamos el rate
-            # segun lo contable y previsualizamos la imputacion con este rate
+        rate = get_accounting_rate(move.company_id.currency_id, move.amount_total_signed, move.amount_total_in_currency_signed, move.currency_id)
+        amount = abs(line.amount_residual) * rate 
+        return amount
 
-            # los rates en realidad existen en los aml de la factura, pero para no tomar arbitrariamente uno sacamos
-            # el rate desde los totales de la factura
-            rate = get_accounting_rate(move.company_id.currency_id, move.amount_total_signed, move.amount_total_in_currency_signed, move.currency_id)
-            for item in move.invoice_outstanding_credits_debits_widget['content']:
-                amount_residual = self.env['account.move.line'].browse(item['id']).amount_residual
-                item['amount'] = move.currency_id.round(amount_residual * rate)
+    ### Comentamos este método debido a que el campo invoice_outstanding_credits_debits_widget no se estaba seteando correctamente en super
+    ### Como FIX agregamos este PR a Odoo: https://github.com/odoo/odoo/pull/170066/files
+
+    # def _compute_payments_widget_to_reconcile_info(self):
+    #     """
+    #     Modificamos el widget para que si la compañía tiene el setting de forzar concilacion en moneda y estamos
+    #     en esa situacion (cuenta deudora no tiene moneda). Entonces el importe que previsualizamos para conciliar
+    #     respeta la modificacion que hacemos al conciliar (basicamente que importa el rate en pesos por lo cual tomamos
+    #     el rate de la factura)
+    #     """
+    #     super()._compute_payments_widget_to_reconcile_info()
+
+    #     def get_accounting_rate(company_currency, amount, amount_currency, currency):
+    #         if company_currency.is_zero(amount) or currency.is_zero(amount_currency):
+    #             return 0.0
+    #         else:
+    #             return abs(amount_currency) / abs(amount)
+
+    #     # TODO tal vez chequear tmb que moneda de factura sea distinta? o eso no influye? habria que ver caso de pagar con usd factura en ars
+    #     for move in self.filtered(
+    #             lambda x: x.invoice_has_outstanding and \
+    #             x.company_id.currency_id != x.currency_id and x.company_id.reconcile_on_company_currency):
+    #         pay_term_lines = move.line_ids\
+    #             .filtered(lambda line: line.account_id.account_type in ('asset_receivable', 'liability_payable'))
+    #         # deberia ser solo una cuenta, pero como super hace un in chequeamos que cualquier cuenta pueda tener moneda
+    #         if any(x.currency_id for x in pay_term_lines.account_id):
+    #             continue
+    #         # para todos los asientos que son en moneda secundaria y que no tengan moneda calculamos el rate
+    #         # segun lo contable y previsualizamos la imputacion con este rate
+
+    #         # los rates en realidad existen en los aml de la factura, pero para no tomar arbitrariamente uno sacamos
+    #         # el rate desde los totales de la factura
+    #         rate = get_accounting_rate(move.company_id.currency_id, move.amount_total_signed, move.amount_total_in_currency_signed, move.currency_id)
+    #         for item in move.invoice_outstanding_credits_debits_widget['content']:
+    #             amount_residual = self.env['account.move.line'].browse(item['id']).amount_residual
+    #             item['amount'] = move.currency_id.round(amount_residual * rate)
 
     @api.depends('invoice_date')
     def _compute_invoice_date_due(self):


### PR DESCRIPTION
Agregamos un nuevo PR a Odoo (https://github.com/odoo/odoo/pull/170066) ajustando el método _compute_payments_widget_to_reconcile_info en super debido a que el campo invoice_outstanding_credits_debits_widget no se setea correctamente