### PR TITLE
[FIX] account_payment_term_surcharge: Correct calculation of next_surcharge_date with day_current_month

### DIFF
--- a/account_payment_term_surcharge/models/account_payment_term_surcharge.py
+++ b/account_payment_term_surcharge/models/account_payment_term_surcharge.py
@@ -59,4 +59,6 @@ class AccountPaymentTermSurcharge(models.Model):
             next_date += relativedelta(day=self.days, months=1)
         elif self.option == 'day_current_month':
             next_date += relativedelta(day=self.days, months=0)
+            if date_ref >= next_date:
+                next_date = date_ref + relativedelta(day=self.days, months=1)
         return next_date


### PR DESCRIPTION

This fix addresses an issue when calculating `next_surcharge_date` for surcharges that depend on a specific day of the current month. For example, if the invoice date is 30/11 and the surcharge is set for the 13th of the month, the calculated `next_surcharge_date` was incorrectly set to 13/11 (a past date).

With this fix, the calculation ensures the `next_surcharge_date` is properly set to 13/12 (the next valid occurrence).