### PR TITLE
[FIX] account_interests: Fix when having interval to run interest

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -176,7 +176,7 @@ class ResCompanyInterest(models.Model):
             aggregates=['amount_residual:sum'],
         )
         for x in previous_grouped_lines:
-            self._update_deuda(deuda, x[0], 'Deuda periodos anteriores', x[1] * self.rate)
+            self._update_deuda(deuda, x[0], 'Deuda periodos anteriores', x[1] * self.rate * self.interval)
 
         # Intereses por el último período
         last_period_lines = self.env['account.move.line'].search(
@@ -184,7 +184,7 @@ class ResCompanyInterest(models.Model):
         )
         for partner, amls in last_period_lines.grouped('partner_id').items():
             interest = sum(
-                move.amount_residual * ((to_date - move.invoice_date_due).days - 1) * (self.rate / interest_rate[self.rule_type])
+                move.amount_residual * ((to_date - move.invoice_date_due).days) * (self.rate / interest_rate[self.rule_type])
                 for move, lines in amls.grouped('move_id').items()
             )
             self._update_deuda(deuda, partner, 'Deuda último periodo', interest)


### PR DESCRIPTION
Se realiza el arreglo de cuando se tiene un intervalo sobre el cual calcular.
Ese intervalo afecta a la deuda de periodos anteriores.

Por ejemplo si se tiene un interes mensual de 0,0068 diario y quiere que se repita cada 5 dias. Entonces a la hora de calcular el interes del perior anterio deberia ser 0,0068 int/dias * 5 dias * deuda

por otro lado, se quita el -1 ya que si se esta incluyenda la fecha de vencimiento entonces lo que ocurria es los siguiente
factura que vence el 15/10 y la corrida es del 16/10
entraba dado ('date_maturity', '>=', from_date) y esta resta (to_date - move.invoice_date_due).days) claramente daba 1 y al restarle luego 1 quedaba en 0 y nunca se cobra ese interes por ese dia de vencimiento