### PR TITLE
[IMP] account_ux: change pdf name of payment receipt

### DIFF
--- a/account_ux/__init__.py
+++ b/account_ux/__init__.py
@@ -5,3 +5,10 @@
 from . import reports
 from . import models
 from . import wizards
+
+
+def _change_receipt_name(env):
+    report = env.ref("account.action_report_payment_receipt")
+    report.print_report_name = (
+        "(object.partner_type == 'supplier' and 'Orden de Pago' or 'Recibo') + ' ' + (object.name or 'Borrador')"
+    )

--- a/account_ux/__manifest__.py
+++ b/account_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account UX",
-    "version": "18.0.1.13.0",
+    "version": "18.0.1.14.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",
@@ -59,4 +59,5 @@
     # instale
     "auto_install": True,
     "application": False,
+    "post_init_hook": "_change_receipt_name",
 }

--- a/account_ux/migrations/18.0.1.14.0/post-migration.py
+++ b/account_ux/migrations/18.0.1.14.0/post-migration.py
@@ -1,0 +1,10 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Change receipt PDF report name"""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    report = env.ref("account.action_report_payment_receipt")
+    report.print_report_name = (
+        "(object.partner_type == 'supplier' and 'Orden de Pago' or 'Recibo') + ' ' + (object.name or 'Borrador')"
+    )


### PR DESCRIPTION
This PR improves the payment receipt report naming by:
•  Adding logic to dynamically set the payment receipt report name based on the partner type
•  For supplier payments: "Orden de Pago + [payment name/Draft]"
•  For customer payments: "Recibo + [payment name/Draft]"

Technical details:
•  Implemented through a post_init_hook and migration script
•  Added function _change_receipt_name to modify the print_report_name of payment receipt report
•  Includes migration script for version 18.0.1.14.0 to apply changes to existing installations
•  Bumped module version from 18.0.1.13.0 to 18.0.1.14.0

The changes ensure proper report naming convention based on the payment type while maintaining backward compatibility through the migration script.