### PR TITLE
[FIX] account_debt_report: fix report with negative amount

### DIFF
--- a/account_debt_report/models/res_partner.py
+++ b/account_debt_report/models/res_partner.py
@@ -75,10 +75,10 @@ class ResPartner(models.Model):
             domain += [('company_id', 'in', self.env.companies.ids)]
             company_currency_ids = self.env.companies.mapped('currency_id')
         if only_currency_lines and len(company_currency_ids) == 1:
-            domain += [('currency_id', 'not in', company_currency_ids.ids), ('amount_currency', '>', 0.0)]
+            domain += [('currency_id', 'not in', company_currency_ids.ids)]
 
         if secondary_currency:
-            domain += [('amount_currency', '>', 0.0)]
+            domain += [('amount_currency', '!=', 0.0)]
 
         if not historical_full:
             domain += [('reconciled', '=', False), ('full_reconcile_id', '=', False)]


### PR DESCRIPTION
When displaying debt report lines in foreign currencies, the system was incorrectly filtering out negative amounts due to a restrictive domain condition (amount_currency > 0.0). This caused missing transactions and incorrect balances in the report.

Fixed by:
•  Removing the positive-only restriction for lines with different currencies than the company currency •  Changing the condition from amount_currency > 0.0 to amount_currency != 0.0 to include all non-zero amounts

This fix ensures that all foreign currency transactions are properly displayed in the debt report, regardless of whether they are positive or negative amounts.