### PR TITLE
[FIX] account_internal_transfer: prevent recompute partner into check…

### DIFF
--- a/account_internal_transfer/__manifest__.py
+++ b/account_internal_transfer/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Internal Transfer",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_internal_transfer/models/account_payment.py
+++ b/account_internal_transfer/models/account_payment.py
@@ -7,11 +7,7 @@ class AccountPayment(models.Model):
 
     is_internal_transfer = fields.Boolean(
         string="Internal Transfer",
-        readonly=False,
-        store=True,
         tracking=True,
-        compute="_compute_is_internal_transfer",
-        precompute=True,
     )
 
     destination_journal_id = fields.Many2one(
@@ -37,15 +33,6 @@ class AccountPayment(models.Model):
         if self.is_internal_transfer:
             return "account_internal_transfer.report_account_transfer"
         return report_xml_id
-
-    @api.depends("partner_id", "journal_id", "destination_journal_id")
-    def _compute_is_internal_transfer(self):
-        for payment in self:
-            payment.is_internal_transfer = (
-                not payment.partner_id or payment.partner_id == payment.journal_id.company_id.partner_id
-            ) and payment.destination_journal_id
-        if self._context.get("is_internal_transfer_menu"):
-            self.is_internal_transfer = True
 
     def _get_aml_default_display_name_list(self):
         values = super()._get_aml_default_display_name_list()
@@ -154,5 +141,5 @@ class AccountPayment(models.Model):
     @api.depends("is_internal_transfer")
     def _compute_partner_id(self):
         super()._compute_partner_id()
-        for pay in self.filtered(lambda x: x.is_internal_transfer):
-            pay.partner_id = pay.journal_id.company_id.partner_id
+        for pay in self.filtered("is_internal_transfer"):
+            pay.partner_id = False

--- a/account_internal_transfer/views/account_payment_views.xml
+++ b/account_internal_transfer/views/account_payment_views.xml
@@ -74,7 +74,7 @@
             'default_is_internal_transfer': True,
             'default_move_journal_types': ('bank', 'cash'),
             'display_account_trust': True,
-            'is_internal_transfer_menu':True}
+            }
         </field>
         <field name="domain">[('is_internal_transfer', '=', True)]</field>
         <field name="help" type="html">


### PR DESCRIPTION
… transfer

When modifying the destination journals of payments created with wizards, the journal_id is recomputed. To avoid this, we remove the depends on the _compute_partner_id method. This is because even though the partner remains the same, this recomputation triggers a chain of dependencies that changes the journal of the paymen