### PR TITLE
[IMP] Add test: Add unit test for stock_account_ux

### DIFF
--- a/stock_account_ux/tests/__init__.py
+++ b/stock_account_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_account_ux

--- a/stock_account_ux/tests/test_stock_account_ux.py
+++ b/stock_account_ux/tests/test_stock_account_ux.py
@@ -1,0 +1,46 @@
+import odoo.tests.common as common
+from odoo import Command, fields
+
+
+class TestStockAccountUx(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.today = fields.Date.today()
+        self.partner_ri = self.env["res.partner"].search([("name", "=", "ADHOC SA")], limit=1)
+
+        self.product_category = self.env.ref("product.product_category_5")
+        self.product_category.property_cost_method = "fifo"
+        self.product = self.env["product.product"].search(
+            [("active", "=", True), ("categ_id", "=", self.product_category.id)], limit=1
+        )
+
+    def test_stock_account_ux(self):
+        purchase_order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner_ri.id,
+                "date_order": self.today,
+                "order_line": [
+                    Command.create({"product_id": self.product.id, "product_qty": 1, "price_unit": 100}),
+                ],
+            }
+        )
+        purchase_order.button_confirm()
+        # Validate picking
+        action = purchase_order.action_view_picking()
+        in_picking = self.env[action["res_model"]].browse(action["res_id"])
+        in_picking.move_ids.quantity = 1
+        in_picking.move_ids.picked = True
+        in_picking.button_validate()
+
+        # Create bill invoice
+        bill = self.env["account.move"].browse(purchase_order.action_create_invoice()["res_id"])
+        bill.invoice_date = self.today
+        bill.purchase_id = purchase_order
+        bill.action_post()
+
+        bill.button_draft()
+        # Create stock_valuation_layer_ids by modifying the price_unit
+        bill.invoice_line_ids.price_unit = 120
+        bill.action_post()
+
+        self.assertTrue(bill.allow_move_with_valuation_cancelation)


### PR DESCRIPTION
This commit introduces a unit test for the stock_account_ux module to ensure that the allow_move_with_valuation_cancelation flag behaves as expected. The test simulates the full flow of a purchase order with a FIFO product: confirming the order, validating the picking, creating and posting the vendor bill, modifying the price unit to trigger valuation changes, and finally asserting that the bill allows move cancellation with valuation layers.

This ensures robustness of the valuation logic in edge cases where invoice values change after the stock move is validated.