### PR TITLE
[FIX] account_journal_security: Adapt _compute_has_moves method in order to be compatible with account_journal_security

### DIFF
--- a/account_journal_security/models/account_move.py
+++ b/account_journal_security/models/account_move.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from odoo import fields, models
+from odoo.tools import SQL
 
 
 class AccountMove(models.Model):
@@ -11,3 +12,30 @@ class AccountMove(models.Model):
     journal_id = fields.Many2one(
         auto_join=True,
     )
+
+    def _compute_has_moves(self):
+        query = self.env["res.partner"]._search([("id", "in", self.ids)])
+        account_move_query = self.env["account.move"]._search(
+            [
+                ("company_id", "in", self.env.companies.ids),
+                "|",
+                ("partner_id", "=", SQL.identifier(query.table, "id")),
+                "|",
+                ("partner_shipping_id", "=", SQL.identifier(query.table, "id")),
+                ("commercial_partner_id", "=", SQL.identifier(query.table, "id")),
+            ]
+        )
+        result = dict(
+            self.env.execute_query(
+                query.select(
+                    "id",
+                    SQL(
+                        "EXISTS (%s) AS has_moves",
+                        account_move_query.subselect(SQL.identifier(account_move_query.table, "id")),
+                    ),
+                )
+            )
+        )
+
+        for partner in self:
+            partner.has_moves = result.get(partner.id, False)


### PR DESCRIPTION


Odoo's recent update (enterprise PR https://github.com/odoo/enterprise/pull/82531) add a _compute_has_moves in res partner.

Since our account_journal_security module relies on forcing the auto-join of the journal_id field from account.move, we had to adjust the way the field is handled in search domains and SQL generation to remain compatible with the new behavior.

This change ensures that journal-based access restrictions continue to function as expected after the upstream modifications.