### PR TITLE
[IMP] account_ux: prevent journal type change if entries exist

### DIFF
--- a/account_ux/models/account_journal.py
+++ b/account_ux/models/account_journal.py
@@ -29,6 +29,17 @@ class AccountJournal(models.Model):
 
     def write(self, vals):
         """We need to allow to change to False the value for restricted for hash for the journal when this value is setted."""
+        if "type" in vals:
+            for journal in self:
+                if journal.type != vals["type"] and vals["type"] not in ("bank", "cash", "credit"):
+                    has_entries = self.env["account.move.line"].search_count([("journal_id", "=", journal.id)]) > 0
+                    if has_entries:
+                        raise ValidationError(
+                            _(
+                                "You cannot change the journal type for '%s' because it already has accounting entries associated with it."
+                            )
+                            % journal.name
+                        )
         if "restrict_mode_hash_table" in vals and not vals.get("restrict_mode_hash_table"):
             restrict_mode_hash_table = vals.get("restrict_mode_hash_table")
             vals.pop("restrict_mode_hash_table")

--- a/account_ux/tests/test_account_ux.py
+++ b/account_ux/tests/test_account_ux.py
@@ -15,9 +15,9 @@ class TestAccountUXChangeCurrency(common.TransactionCase):
 
         self.journal_usd = self.env.ref("account.1_sale")
 
-        self.journal_ars = self.env.ref("account.1_purchase")
+        self.journal_ars = self.journal_usd.copy()
 
-        self.journal_ars.write({"type": "sale", "currency_id": self.currency_ars})
+        self.journal_ars.write({"currency_id": self.currency_ars})
 
     def test_account_ux_change_currency(self):
         invoice = self.env["account.move"].create(


### PR DESCRIPTION
Prevent changing the journal type on account.journal records that already have associated account.move.line entries, unless the new type is 'bank', 'cash', or 'credit'.

This helps preserve accounting integrity by avoiding type changes that could lead to inconsistencies in existing journal entries.

Allowed exceptions are made for operational types like 'bank', 'cash', and 'credit', where type changes are considered safe.