### PR TITLE
[IMP] account_ux: prevent tax changes when used in accounting entries

### DIFF
--- a/account_ux/models/__init__.py
+++ b/account_ux/models/__init__.py
@@ -12,3 +12,4 @@ from . import res_currency_rate
 from . import account_move
 from . import account_chart_template
 from . import account_payment
+from . import account_tax

--- a/account_ux/models/account_tax.py
+++ b/account_ux/models/account_tax.py
@@ -1,0 +1,16 @@
+from odoo import api, models
+from odoo.exceptions import ValidationError
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    @api.constrains("amount_type", "price_include_override", "include_base_amount", "is_base_affected", "amount")
+    def _check_company_matches_active_company(self):
+        for tax in self:
+            has_move_lines = self.env["account.move.line"].sudo().search([("tax_ids", "in", tax.ids)], limit=1)
+            if has_move_lines:
+                raise ValidationError(
+                    "The tax computation fields cannot be modified because there are accounting entries linked to this tax. "
+                    "We recommend creating a new tax and archiving this one if necessary."
+                )


### PR DESCRIPTION
Prevent changes to critical tax fields such as amount, amount type, and base configuration once the tax has been used in accounting entries (account.move.line).

Modifying these fields after the tax has already been applied could lead to inconsistent financial data or miscalculations. To ensure data integrity, a constraint was added to block changes to the following fields:
- amount_type
- price_include_override
- include_base_amount
- is_base_affected
- amount

If the tax is found in any existing move line, a ValidationError is raised to prevent the update.