### PR TITLE
[FIX] account_journal_security: Fix access rights when having journal_restriction in modification mode.

### DIFF
--- a/account_journal_security/models/account_journal.py
+++ b/account_journal_security/models/account_journal.py
@@ -119,8 +119,6 @@ class AccountJournal(models.Model):
             if limit == 1 and journal_ids:
                 # Agregamos el domain de los journals donde el usuario tiene permisos
                 domain += [
-                    "&",
-                    ("modification_user_ids", "=", False),
                     "|",
                     ("user_ids", "=", False),
                     ("id", "in", journal_ids),


### PR DESCRIPTION
When having journal_restriction in modification mode and trying to create a new account move a raise was raised 
because was inconsistent the domain.

If journal_ids variable is defined, it's not necessary (nor valid) to explicitly set modification_journal_ids to False.
In fact, with journal_restriction enabled, it's not possible for modification_journal_ids to be False, as this would contradict the restriction logic.