### PR TITLE
[FIX] account_journal_security: Fix access rights when having journal_restriction in modification mode.

### DIFF
--- a/account_journal_security/models/account_journal.py
+++ b/account_journal_security/models/account_journal.py
@@ -115,9 +115,11 @@ class AccountJournal(models.Model):
             journal_ids = (user.journal_ids.ids + user.modification_journal_ids.ids)
             if limit == 1 and journal_ids:
                 # Agregamos el domain de los journals donde el usuario tiene permisos
-                domain += ['&',('modification_user_ids', '=', False),'|',
-                           ('user_ids', '=', False),
-                           ('id', 'in', journal_ids)]
+                domain += [
+                    '|',
+                    ('user_ids', '=', False),
+                    ('id', 'in', journal_ids),
+                ]
         return super()._search(domain, offset, limit, order, access_rights_uid=access_rights_uid)
 
     @api.onchange('journal_restriction')


### PR DESCRIPTION
When having journal_restriction in modification mode and trying to create a new account move a raise was raised
because was inconsistent the domain.

If journal_ids variable is defined, it's not necessary (nor valid) to explicitly set modification_journal_ids to False.
In fact, with journal_restriction enabled, it's not possible for modification_journal_ids to be False, as this would contradict the restriction logic.