### PR TITLE
[FIX] account_debt_report: Correct balance calculation

### DIFF
--- a/account_debt_report/models/res_partner.py
+++ b/account_debt_report/models/res_partner.py
@@ -176,7 +176,12 @@ class ResPartner(models.Model):
             amount_currency = record.amount_currency
             amount_residual_currency = record.amount_residual_currency
             show_currency = record.currency_id != record.company_id.currency_id
-            balance_currency += record.amount_currency if show_currency else 0.0
+
+            if historical_full:
+                balance_currency += record.amount_currency if show_currency else 0.0
+            else:
+                balance_currency += record.amount_residual_currency if show_currency else 0.0
+
             if record.payment_id:
                 name += " - " + record.journal_id.name
 


### PR DESCRIPTION
1. The code now checks if historical_full is True before deciding which amount to use for the balance calculation
2. If historical_full is True:
•  Uses record.amount_currency (original behavior)
3. If historical_full is False:
•  Uses record.amount_residual_currency (new behavior)

This change ensures that the foreign currency balances are calculated using the residual (remaining) amount in the foreign currency rather than the total amount, unless historical full view is requested. This is likely to provide more accurate balance calculations for partially paid invoices or bills in foreign currencies.

The fix only applies when dealing with transactions in a different currency than the company's currency (checked by show_currency = record.currency_id != record.company_id.currency_id).