### PR TITLE
[FIX] account_interest: Allow dynamica context for domain evaluation

### DIFF
--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -3,7 +3,7 @@
 # directory
 ##############################################################################
 from odoo import models, fields, api, _
-from odoo.tools.safe_eval import safe_eval
+from odoo.tools import safe_eval
 from dateutil.relativedelta import relativedelta
 from odoo.exceptions import UserError
 import logging
@@ -149,7 +149,7 @@ class ResCompanyInterest(models.Model):
             ('parent_state', '=', 'posted'),
         ]
         if self.domain:
-            move_line_domain += safe_eval(self.domain)
+            move_line_domain += safe_eval.safe_eval(self.domain)
         return move_line_domain
 
     def _update_deuda(self, deuda, partner, key, value):
@@ -214,7 +214,7 @@ class ResCompanyInterest(models.Model):
                 ('credit_move_id.date', '<', to_date)]
             
             if self.domain:
-                partial_domain.append(('debit_move_id', 'any', safe_eval(self.domain)))
+                partial_domain.append(('debit_move_id', 'any', safe_eval.safe_eval(self.domain)))
             
             partials = self.env['account.partial.reconcile'].search(partial_domain).filtered(lambda x: x.credit_move_id.date > x.debit_move_id.date_maturity).grouped('debit_move_id')
             for move_line, parts in partials.items():
@@ -362,4 +362,12 @@ class ResCompanyInterest(models.Model):
     @api.depends('domain')
     def _compute_has_domain(self):
         for rec in self:
-            rec.has_domain = len(safe_eval(rec.domain)) > 0
+            domain = rec.domain or '[]'
+            evaluated_domain = safe_eval.safe_eval(domain, {
+                'context_today': safe_eval.datetime.datetime.today,
+                'datetime': safe_eval.datetime,
+                'dateutil': safe_eval.dateutil,
+                'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
+                'time': safe_eval.time,
+            })
+            rec.has_domain = len(evaluated_domain) > 0


### PR DESCRIPTION
Ensure that the 'domain' field is safely evaluated in _compute_has_domain by using the appropriate context for safe_eval, including datetime, dateutil, relativedelta, and time. Prevents evaluation errors and enforces secure execution of dynamic domains.