### PR TITLE
[FIX] account_interest: fix safe_eval context type to avoid warning

### DIFF
--- a/account_interests/__manifest__.py
+++ b/account_interests/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Interests Management',
-    'version': "17.0.1.4.0",
+    'version': "17.0.1.5.0",
     'category': 'Accounting',
     'sequence': 14,
     'summary': 'Calculate interests for selected partners',

--- a/account_interests/models/res_company_interest.py
+++ b/account_interests/models/res_company_interest.py
@@ -181,7 +181,7 @@ class ResCompanyInterest(models.Model):
             ('parent_state', '=', 'posted'),
         ]
         if self.domain:
-            move_line_domain += safe_eval.safe_eval(self.domain)
+            move_line_domain += safe_eval.safe_eval(self.domain, self._get_eval_context())
         return move_line_domain
 
     def _update_deuda(self, deuda, partner, key, value):
@@ -246,7 +246,7 @@ class ResCompanyInterest(models.Model):
                 ('credit_move_id.date', '<', to_date)]
             
             if self.domain:
-                partial_domain.append(('debit_move_id', 'any', safe_eval.safe_eval(self.domain)))
+                partial_domain.append(('debit_move_id', 'any', safe_eval.safe_eval(self.domain, self._get_eval_context())))
             
             partials = self.env['account.partial.reconcile'].search(partial_domain).filtered(lambda x: x.credit_move_id.date > x.debit_move_id.date_maturity).grouped('debit_move_id')
             for move_line, parts in partials.items():
@@ -396,15 +396,21 @@ class ResCompanyInterest(models.Model):
 
         return invoice_vals
 
-    @api.depends('domain')
+    @api.depends("domain")
     def _compute_has_domain(self):
         for rec in self:
-            domain = rec.domain or '[]'
-            evaluated_domain = safe_eval.safe_eval(domain, {
-                'context_today': safe_eval.datetime.datetime.today,
-                'datetime': safe_eval.datetime,
-                'dateutil': safe_eval.dateutil,
-                'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
-                'time': safe_eval.time,
-            })
+            domain = rec.domain or "[]"
+            evaluated_domain = safe_eval.safe_eval(domain, self._get_eval_context())
             rec.has_domain = len(evaluated_domain) > 0
+
+    def _get_eval_context(self):
+        """Prepare the context used when evaluating python code
+        :returns: dict -- evaluation context given to safe_eval
+        """
+        return {
+            'context_today': safe_eval.datetime.datetime.today,
+            'datetime': safe_eval.datetime,
+            'dateutil': safe_eval.dateutil,
+            'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
+            'time': safe_eval.time,
+        }

--- a/account_interests/views/res_company_views.xml
+++ b/account_interests/views/res_company_views.xml
@@ -40,7 +40,7 @@
                                     <field name="next_date"/>
                                     <field name="late_payment_interest"/>
                                 </group>
-                                <field name="domain" widget="domain" options="{ 'model': 'account.move.line', 'in_dialog': True }" />
+                                <field name="domain" widget="domain" options="{ 'model': 'account.move.line', 'in_dialog': True, 'allow_expressions': True }" />
                             </group>
                         </form>
                     </field>


### PR DESCRIPTION
This commit fixes a warning raised by safe_eval due to an incorrect evaluation context type.

The _get_eval_context method was returning a tuple instead of a dictionary

We now return a plain dictionary to ensure the evaluation context is correctly interpreted, avoiding the warning and ensuring compatibility with future Odoo versions.