### PR TITLE
[FIX] account_ux: Include company_id filter in suspense account assignment

### DIFF
--- a/account_ux/models/chart_template.py
+++ b/account_ux/models/chart_template.py
@@ -14,5 +14,6 @@ class AccountChartTemplate(models.AbstractModel):
         company = (company or self.env.company)
         suspense_account = self.env['res.company'].browse(company.id).account_journal_suspense_account_id
         self.env['account.journal'].search([('type', 'in', ['bank', 'cash']),
+                                            ('company_id', '=', company.id),
                                             ('suspense_account_id', '=', False)
                                             ]).write({'suspense_account_id': suspense_account})


### PR DESCRIPTION

Added the `company_id` filter when assigning the suspense account (`suspense_account_id`) to journals of type 'bank' and 'cash'. Without this filter, journals from other companies were being incorrectly updated, causing inconsistencies in multi-company setups.