### PR TITLE
[IMP] account_ux: Unlink inactive tax when duplicate invoice

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 import json
 import base64
-from odoo import models, api, fields, _
+from odoo import models, api, fields, _, Command
 from odoo.exceptions import UserError
 
 
@@ -70,6 +70,10 @@ class AccountMove(models.Model):
 
     def copy(self, default=None):
         res = super().copy(default=default)
+        for line_to_clean in res.mapped("line_ids").filtered(lambda x: False in x.mapped("tax_ids.active")):
+            line_to_clean.tax_ids = [
+                Command.unlink(x.id) for x in line_to_clean.tax_ids.filtered(lambda x: not x.active)
+            ]
         res._onchange_partner_commercial()
         return res
 


### PR DESCRIPTION
When archiving/deactivating taxes that were used in OS and invoices and then duplicating any of these records, the system copies the lines while keeping the archived taxes in the new record. This allows you to validate OV or invoice with archived taxes at the time of execution. Ideally, it should allow duplication, but the idea is to delete the tax from the line if it is archived.