### PR TITLE
[IMP] account_internal_transfer: Reorganize Bank and Cash menu position

### DIFF
--- a/account_internal_transfer/__manifest__.py
+++ b/account_internal_transfer/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Internal Transfer",
-    "version": "18.0.1.5.0",
+    "version": "18.0.1.6.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_internal_transfer/views/account_payment_views.xml
+++ b/account_internal_transfer/views/account_payment_views.xml
@@ -84,7 +84,7 @@
         </field>
     </record>
 
-    <menuitem id="menu_finance_bank_and_cash" parent="account.menu_finance" sequence="4" groups="account.group_account_basic" name="Bank and Cash"/>
+    <menuitem id="menu_finance_bank_and_cash" parent="account.menu_finance" sequence="3" groups="account.group_account_basic" name="Bank and Cash"/>
 
     <menuitem action="action_account_payments_transfer" id="menu_action_account_payments_transfer" parent="menu_finance_bank_and_cash" sequence="30" groups="account.group_account_basic"/>
 </odoo>


### PR DESCRIPTION
The "Bank and Cash" menu is now displayed to the left of the "Accounting" menu to improve navigation and align with the logical flow of accounting operations. This change enhances usability by placing frequently used options in a more accessible location.