### PR TITLE
[FIX] account_ux: back to draft for hashed entries

### DIFF
--- a/account_ux/__init__.py
+++ b/account_ux/__init__.py
@@ -5,6 +5,8 @@
 from . import reports
 from . import models
 from . import wizards
+from .monkey_patches import monkey_patches
+from .hooks import uninstall_hook
 
 
 def _change_receipt_name(env):

--- a/account_ux/__manifest__.py
+++ b/account_ux/__manifest__.py
@@ -61,4 +61,6 @@
     "auto_install": True,
     "application": False,
     "post_init_hook": "_change_receipt_name",
+    "post_load": "monkey_patches",
+    "uninstall_hook": "uninstall_hook",
 }

--- a/account_ux/hooks.py
+++ b/account_ux/hooks.py
@@ -1,0 +1,13 @@
+from odoo.addons.sale_order_type.models.account_move import AccountMove
+
+
+def _revert_method(cls, name):
+    """Revert the original method called ``name`` in the given class.
+    See :meth:`~._patch_method`.
+    """
+    method = getattr(cls, name)
+    setattr(cls, name, method.origin)
+
+
+def uninstall_hook(env):
+    _revert_method(AccountMove, "_compute_show_reset_to_draft_button")

--- a/account_ux/models/account_journal.py
+++ b/account_ux/models/account_journal.py
@@ -29,17 +29,6 @@ class AccountJournal(models.Model):
 
     def write(self, vals):
         """We need to allow to change to False the value for restricted for hash for the journal when this value is setted."""
-        if "type" in vals:
-            for journal in self:
-                if journal.type != vals["type"] and vals["type"] not in ("bank", "cash", "credit"):
-                    has_entries = self.env["account.move.line"].search_count([("journal_id", "=", journal.id)]) > 0
-                    if has_entries:
-                        raise ValidationError(
-                            _(
-                                "You cannot change the journal type for '%s' because it already has accounting entries associated with it."
-                            )
-                            % journal.name
-                        )
         if "restrict_mode_hash_table" in vals and not vals.get("restrict_mode_hash_table"):
             restrict_mode_hash_table = vals.get("restrict_mode_hash_table")
             vals.pop("restrict_mode_hash_table")

--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -230,3 +230,10 @@ class AccountMove(models.Model):
         tax_totals["total_amount"] = tax_totals["base_amount"] + subtotal["tax_amount"]
 
         return tax_totals
+
+    def button_draft(self):
+        for move in self:
+            if move.inalterable_hash and not move.journal_id.restrict_mode_hash_table:
+                move.env.cr.execute("update account_move set inalterable_hash = null where id = %s", (move.id,))
+                move.invalidate_recordset(["inalterable_hash"])
+        return super().button_draft()

--- a/account_ux/monkey_patches.py
+++ b/account_ux/monkey_patches.py
@@ -1,0 +1,28 @@
+from odoo import api
+from odoo.addons.account.models.account_move import AccountMove
+
+
+def monkey_patches():
+    # monkey patch
+    # Bypasseamos el método _compute_show_reset_to_draft_button de account para que permita volver a borrador
+    # si se desmarca en restrict_mode_hash_table en el journal
+    # de esta manera se mantiene a formulario para que vaya al super del padre
+    def _compute_show_reset_to_draft_button(self):
+        for move in self:
+            move.show_reset_to_draft_button = (
+                not self._is_move_restricted(move)
+                and not move.journal_id.restrict_mode_hash_table
+                and (move.state == "cancel" or (move.state == "posted" and not move.need_cancel_request))
+            )
+
+    AccountMove._compute_show_reset_to_draft_button = _compute_show_reset_to_draft_button
+
+    def _patch_method(cls, name, method):
+        origin = getattr(cls, name)
+        method.origin = origin
+        # propagate decorators from origin to method, and apply api decorator
+        wrapped = api.propagate(origin, method)
+        wrapped.origin = origin
+        setattr(cls, name, wrapped)
+
+    _patch_method(AccountMove, "_compute_show_reset_to_draft_button", _compute_show_reset_to_draft_button)


### PR DESCRIPTION
Desde que odoo introdujo lo de hash (y deprecó lo anterior) la idea de odoo by adhoc fue de que si el usuario DESMARCA el usar hash en el journal, se puedan volver a borrador asientos (aún si tienen hash).

Vamos a replantear esto en 19 y ver si nos unimos a lo nativo de odoo, eso implicaría:
a) deprecar todo parche en este módulo respecto a hash
b) promocionar NO Usar la protección de hash
c) probablemente desmarcar y borrar hash para todo el que migra (por defecto)
d) evaluar recomendaciones (Y eventualmente necesidad de alguna mejora) para casos de uso donde uno queira proteger ciertos asientos. (pero sin la fuerza de lo de hash que es para una inelterabildiad eterna)

Por el momento, en 18, creemos que esto es lo más consistente y facil de implementar.

En este mismo pr estamos borrando una protección que se había agregado sobre journals que NO está funcionando y no tiene sentido