### PR TITLE
[IMP] account_ux: Add visual distinction for domestic fiscal positions

### DIFF
--- a/account_ux/__manifest__.py
+++ b/account_ux/__manifest__.py
@@ -40,6 +40,7 @@
         "wizards/account_move_change_rate_views.xml",
         "wizards/res_config_settings_views.xml",
         "views/account_account_views.xml",
+        "views/account_fiscal_position_views.xml",
         "views/account_journal_views.xml",
         "views/account_move_line_views.xml",
         "views/account_reconcile_views.xml",

--- a/account_ux/models/__init__.py
+++ b/account_ux/models/__init__.py
@@ -13,3 +13,4 @@ from . import account_move
 from . import account_chart_template
 from . import account_payment
 from . import account_tax
+from . import account_fiscal_position

--- a/account_ux/models/account_fiscal_position.py
+++ b/account_ux/models/account_fiscal_position.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = "account.fiscal.position"
+
+    sequence = fields.Integer(default=999)

--- a/account_ux/views/account_fiscal_position_views.xml
+++ b/account_ux/views/account_fiscal_position_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Tree view with green color for domestic positions -->
+    <record id="view_account_fiscal_position_tree_ux" model="ir.ui.view">
+        <field name="name">account.fiscal.position.tree.ux</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="inherit_id" ref="account.view_account_position_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="attributes">
+                <attribute name="decoration-success">is_domestic</attribute>
+                <attribute name="decoration-bf">is_domestic</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Form view with green title for domestic positions -->
+    <record id="view_account_fiscal_position_form_ux" model="ir.ui.view">
+        <field name="name">account.fiscal.position.form.ux</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="inherit_id" ref="account.view_account_position_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="attributes">
+                <attribute name="style">color: #28a745; font-weight: bold;</attribute>
+                <attribute name="invisible">not is_domestic</attribute>
+            </xpath>
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="name" invisible="is_domestic" style="font-weight: normal;"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add visual distinction for domestic fiscal positions

This improvement makes domestic fiscal positions easily identifiable across the interface with the following enhancements:

* List view: Domestic positions displayed in green with bold text
* Form view: Name field shown in green and bold for domestic positions
* Consistent styling across all views (list, form, selectors)

The changes help users quickly identify the company's domestic fiscal position, improving usability and reducing configuration errors.

Technical changes:
- Extended account.fiscal.position
- Added view inheritance for list and form views with decoration attributes
- Used standard Odoo decoration-success and decoration-bf for styling