### PR TITLE
[IMP] account_ux: Add default invoice report attachment to email templates for invoices and credit notes as used to be in previous version

### DIFF
--- a/account_ux/__manifest__.py
+++ b/account_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account UX",
-    "version": "18.0.1.23.0",
+    "version": "18.0.1.24.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",
@@ -36,6 +36,7 @@
     "data": [
         "security/account_ux_security.xml",
         "security/ir.model.access.csv",
+        "data/mail_template_data.xml",
         "wizards/account_change_currency_views.xml",
         "wizards/account_move_change_rate_views.xml",
         "wizards/res_config_settings_views.xml",

--- a/account_ux/data/mail_template_data.xml
+++ b/account_ux/data/mail_template_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Update email template for invoices to include default report -->
+    <record id="account.email_template_edi_invoice" model="mail.template">
+        <field name="report_template_ids" eval="[(4, ref('account.account_invoices'))]"/>
+    </record>
+
+    <!-- Update email template for credit notes to include default report -->
+    <record id="account.email_template_edi_credit_note" model="mail.template">
+        <field name="report_template_ids" eval="[(4, ref('account.account_invoices'))]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION


- Update email_template_edi_invoice to include account_invoices report by default
- Update email_template_edi_credit_note to include account_invoices report by default
- Create data/mail_template_data.xml to override base templates
- Users will now get PDF attachments automatically when sending invoices/credit notes via email

This improves UX by ensuring invoice PDFs are always attached to outgoing emails, reducing the need for manual attachment selection.