### PR TITLE
[FIX] account_exchange_difference_invoice: fix confirm entries reconciliation

### DIFF
--- a/account_exchange_difference_invoice/models/account_move.py
+++ b/account_exchange_difference_invoice/models/account_move.py
@@ -29,8 +29,8 @@ class AccountMove(models.Model):
             results["special_mode"] = "total_included"
         return results
 
-    def action_post(self):
-        res = super().action_post()
+    def _post(self, soft=True):
+        res = super()._post(soft=soft)
         for move in self:
             reverse_moves = move.exchange_reversed_move_ids
             if not reverse_moves:


### PR DESCRIPTION
Use _post instead of action_post to ensure that is called also when confirming multiple entries at once. action_post calls _post internally, so it doesn't change the current behavior when confirming a single entry.