### PR TITLE
[FIX] account_journal_security:  handle non-list domain in _search

### DIFF
--- a/account_journal_security/models/account_journal.py
+++ b/account_journal_security/models/account_journal.py
@@ -111,6 +111,9 @@ class AccountJournal(models.Model):
         permiso ya que si no pueden ver los diarios termina dando errores en
         cualquier lugar que se use un campo related a algo del diario
         """
+        # Ensure domain is a list
+        if not isinstance(domain, list):
+            domain = []
         user = self.env.user
         # Agregamos el with_user ya que por alguna razon llega con sudo y nos da un falso positivo indicando
         # que el usuario es super usuario. De esta forma nos aseguramos verdaderamente si lo es.


### PR DESCRIPTION
The _search method was failing when domain parameter was passed as a boolean value instead of a list, causing a TypeError when trying to use the += operator.

Added type checking to ensure domain is always converted to a list before performing list operations on it.

Fixes: TypeError: unsupported operand type(s) for +=: 'bool' and 'list'