### PR TITLE
[IMP] account_internal_transfer: transfer entries in company currency

### DIFF
--- a/account_internal_transfer/i18n/account_internal_transfer.pot
+++ b/account_internal_transfer/i18n/account_internal_transfer.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-03 20:00+0000\n"
-"PO-Revision-Date: 2025-12-03 20:00+0000\n"
+"POT-Creation-Date: 2026-01-21 14:05+0000\n"
+"PO-Revision-Date: 2026-01-21 14:05+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -47,6 +47,18 @@ msgstr ""
 msgid ""
 "<br/>\n"
 "                <strong>Total Transacción:</strong>"
+msgstr ""
+
+#. module: account_internal_transfer
+#. odoo-python
+#: code:addons/account_internal_transfer/models/account_payment.py:0
+msgid ""
+"<div class=\"alert alert-warning\" role=\"alert\"><i class=\"fa fa-"
+"exclamation-triangle\"></i> This payment is in <strong>%s</strong> state but"
+" the paired one is in <strong>%s</strong> state. Ensure both are in the same"
+" state when finished making changes. <a href=\"%s\" class=\"btn btn-sm btn-"
+"warning\" style=\"margin-left: 10px;\"><i class=\"fa fa-external-link\"></i>"
+" Go to Paired Payment</a></div>"
 msgstr ""
 
 #. module: account_internal_transfer
@@ -143,6 +155,12 @@ msgid "Main Company"
 msgstr ""
 
 #. module: account_internal_transfer
+#. odoo-python
+#: code:addons/account_internal_transfer/models/account_payment.py:0
+msgid "Paired Payment"
+msgstr ""
+
+#. module: account_internal_transfer
 #: model:ir.model,name:account_internal_transfer.model_account_payment
 msgid "Payments"
 msgstr ""
@@ -150,6 +168,11 @@ msgstr ""
 #. module: account_internal_transfer
 #: model:ir.actions.report,name:account_internal_transfer.action_report_account_transfer
 msgid "Reporte de Transferencia"
+msgstr ""
+
+#. module: account_internal_transfer
+#: model:ir.model.fields,field_description:account_internal_transfer.field_account_payment__show_warning
+msgid "Show Warning"
 msgstr ""
 
 #. module: account_internal_transfer

--- a/account_internal_transfer/i18n/es.po
+++ b/account_internal_transfer/i18n/es.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-03 20:00+0000\n"
-"PO-Revision-Date: 2025-12-18 18:10+0000\n"
+"POT-Creation-Date: 2026-01-21 14:11+0000\n"
+"PO-Revision-Date: 2026-01-21 14:11+0000\n"
 "Last-Translator: carla spiaggi <sca@adhoc.inc>\n"
 "Language-Team: Spanish <https://translation.dev-adhoc.com/projects/"
 "account-financial-tools-19-0/"
@@ -68,16 +68,31 @@ msgstr ""
 "                <strong>Total Transacción:</strong>"
 
 #. module: account_internal_transfer
+#. odoo-python
+#: code:addons/account_internal_transfer/models/account_payment.py:0
+msgid ""
+"<div class=\"alert alert-warning\" role=\"alert\"><i class=\"fa fa-"
+"exclamation-triangle\"></i> This payment is in <strong>%s</strong> state but"
+" the paired one is in <strong>%s</strong> state. Ensure both are in the same"
+" state when finished making changes. <a href=\"%s\" class=\"btn btn-sm btn-"
+"warning\" style=\"margin-left: 10px;\"><i class=\"fa fa-external-link\"></i>"
+" Go to Paired Payment</a></div>"
+msgstr ""
+"<div class=\"alert alert-warning\" role=\"alert\"><i class=\"fa fa-"
+"exclamation-triangle\"></i> Este pago está en estado <strong>%s</strong> pero"
+" el pago relacionado está en estado <strong>%s</strong>. Asegúrese de que ambos estén en el mismo"
+" estado cuando termine de hacer cambios. <a href=\"%s\" class=\"btn btn-sm btn-"
+"warning\" style=\"margin-left: 10px;\"><i class=\"fa fa-external-link\"></i>"
+" Ir al Pago Emparejado</a></div>"
+
+#. module: account_internal_transfer
 #: model_terms:ir.ui.view,arch_db:account_internal_transfer.view_account_payment_form
 msgid ""
-"<span invisible=\"paired_internal_transfer_payment_id or not "
-"is_internal_transfer or state != 'draft'\" class=\"fst-italic\">\n"
-"                        A second payment will be created in the destination "
-"journal.\n"
+"<span invisible=\"paired_internal_transfer_payment_id or not is_internal_transfer or state != 'draft'\" class=\"fst-italic\">\n"
+"                        A second payment will be created in the destination journal.\n"
 "                    </span>"
 msgstr ""
-"<span invisible=\"paired_internal_transfer_payment_id or not "
-"is_internal_transfer or state != 'draft'\" class=\"fst-italic\">\n"
+"<span invisible=\"paired_internal_transfer_payment_id or not is_internal_transfer or state != 'draft'\" class=\"fst-italic\">\n"
 "                        Un segundo pago se creará en el diario destino.\n"
 "                    </span>"
 
@@ -167,6 +182,12 @@ msgid "Main Company"
 msgstr "Empresa Principal"
 
 #. module: account_internal_transfer
+#. odoo-python
+#: code:addons/account_internal_transfer/models/account_payment.py:0
+msgid "Paired Payment"
+msgstr "Pago Emparejado"
+
+#. module: account_internal_transfer
 #: model:ir.model,name:account_internal_transfer.model_account_payment
 msgid "Payments"
 msgstr "Pagos"
@@ -177,10 +198,16 @@ msgid "Reporte de Transferencia"
 msgstr "Reporte de Transferencia"
 
 #. module: account_internal_transfer
+#: model:ir.model.fields,field_description:account_internal_transfer.field_account_payment__show_warning
+msgid "Show Warning"
+msgstr "Mostrar Advertencia"
+
+#. module: account_internal_transfer
 #. odoo-python
 #: code:addons/account_internal_transfer/models/account_payment.py:0
 msgid ""
-"The origin or destination payment methods do not have an outstanding account."
+"The origin or destination payment methods do not have an outstanding "
+"account."
 msgstr ""
 "Los métodos de pago de origen o destino no tienen una cuenta pendiente."
 

--- a/account_internal_transfer/models/account_payment.py
+++ b/account_internal_transfer/models/account_payment.py
@@ -194,3 +194,31 @@ class AccountPayment(models.Model):
         super()._compute_partner_id()
         for pay in self.filtered("is_internal_transfer"):
             pay.partner_id = False
+
+    def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
+        # Call the parent method to get the default move line values
+        line_vals_list = super()._prepare_move_line_default_vals(
+            write_off_line_vals=write_off_line_vals, force_balance=force_balance
+        )
+        # If the destination journal uses a different currency than the company and this is not a paired internal transfer
+        # (to avoid conversion in the entries of new payment, that should be in secondary currency)
+        if (
+            # This is to avoid dependency on payment_pro
+            "amount_company_currency" in self._fields
+            and self.is_internal_transfer
+            and self.destination_journal_id.currency_id != self.company_id.currency_id
+            and not self.paired_internal_transfer_payment_id
+        ):
+            for line_vals in line_vals_list:
+                if "amount_currency" in line_vals:
+                    # Set the currency to the company's currency
+                    line_vals["currency_id"] = self.company_id.currency_id.id
+                    # Adjust the amount_currency based on whether it's a debit or credit
+                    if line_vals["debit"] > 0:
+                        line_vals["amount_currency"] = self.amount_company_currency
+                    elif line_vals["credit"] > 0:
+                        line_vals["amount_currency"] = -self.amount_company_currency
+                    else:
+                        # When both debit and credit are zero, ensure amount_currency is neutral
+                        line_vals["amount_currency"] = 0.0
+        return line_vals_list

--- a/account_internal_transfer/models/account_payment.py
+++ b/account_internal_transfer/models/account_payment.py
@@ -1,3 +1,4 @@
+from markupsafe import Markup, escape
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
@@ -29,6 +30,7 @@ class AccountPayment(models.Model):
         compute="_compute_main_company",
     )
     available_partner_bank_ids = fields.Many2many(compute_sudo=True)
+    show_warning = fields.Html(compute="_compute_show_warning")
 
     @api.depends("company_id", "is_internal_transfer")
     def _compute_destination_company_id(self):
@@ -196,18 +198,18 @@ class AccountPayment(models.Model):
             pay.partner_id = False
 
     def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
-        # Call the parent method to get the default move line values
         line_vals_list = super()._prepare_move_line_default_vals(
             write_off_line_vals=write_off_line_vals, force_balance=force_balance
         )
-        # If the destination journal uses a different currency than the company and this is not a paired internal transfer
-        # (to avoid conversion in the entries of new payment, that should be in secondary currency)
+
         if (
             # This is to avoid dependency on payment_pro
             "amount_company_currency" in self._fields
             and self.is_internal_transfer
+            # Payment journal is in company currency (either not set or explicitly set to company currency)
+            and (not self.journal_id.currency_id or self.journal_id.currency_id == self.company_id.currency_id)
+            and self.destination_journal_id.currency_id  # Destination journal has a different currency
             and self.destination_journal_id.currency_id != self.company_id.currency_id
-            and not self.paired_internal_transfer_payment_id
         ):
             for line_vals in line_vals_list:
                 if "amount_currency" in line_vals:
@@ -222,3 +224,73 @@ class AccountPayment(models.Model):
                         # When both debit and credit are zero, ensure amount_currency is neutral
                         line_vals["amount_currency"] = 0.0
         return line_vals_list
+
+    def write(self, vals):
+        res = super().write(vals)
+        # Avoid recursion when updating paired payments
+        if self.env.context.get("skip_paired_payment_update"):
+            return res
+
+        # Update paired payment when amount or journal changes
+        for payment in self.filtered(lambda p: p.is_internal_transfer and p.paired_internal_transfer_payment_id):
+            paired_payment = payment.paired_internal_transfer_payment_id
+            updates = {}
+
+            # Sync amount
+            if "amount" in vals and payment.amount != paired_payment.amount:
+                updates["amount"] = payment.amount
+
+            # Sync journals (swapped relationship)
+            if "journal_id" in vals and payment.journal_id != paired_payment.destination_journal_id:
+                updates["destination_journal_id"] = payment.journal_id.id
+
+            if "destination_journal_id" in vals and payment.destination_journal_id != paired_payment.journal_id:
+                updates["journal_id"] = payment.destination_journal_id.id
+
+            # Apply updates to paired payment
+            if updates:
+                paired_payment.with_context(skip_paired_payment_update=True).write(updates)
+
+        return res
+
+    @api.depends("state", "paired_internal_transfer_payment_id.state")
+    def _compute_show_warning(self):
+        for pay in self:
+            paired_pay = pay.paired_internal_transfer_payment_id
+            if pay.is_internal_transfer and paired_pay and paired_pay.state != pay.state:
+                state_labels = dict(pay._fields["state"]._description_selection(pay.env))
+                base_url = pay.env["ir.config_parameter"].sudo().get_param("web.base.url")
+                action_url = f"{base_url}/web#id={paired_pay.id}&model=account.payment&view_type=form"
+                # Escape all dynamic values to prevent XSS
+                pay_state = escape(state_labels.get(pay.state, pay.state))
+                paired_state = escape(state_labels.get(paired_pay.state, paired_pay.state))
+                safe_url = escape(action_url)
+                pay.show_warning = Markup(
+                    _(
+                        '<div class="alert alert-warning" role="alert">'
+                        '<i class="fa fa-exclamation-triangle"></i> '
+                        "This payment is in <strong>%s</strong> state but the paired one is in <strong>%s</strong> state. "
+                        "Ensure both are in the same state when finished making changes. "
+                        '<a href="%s" class="btn btn-sm btn-warning" style="margin-left: 10px;">'
+                        '<i class="fa fa-external-link"></i> Go to Paired Payment'
+                        "</a>"
+                        "</div>"
+                    )
+                ) % (pay_state, paired_state, safe_url)
+            else:
+                pay.show_warning = ""
+
+    def action_open_paired_payment(self):
+        """Navigate to the paired internal transfer payment."""
+        self.ensure_one()
+        if not self.paired_internal_transfer_payment_id:
+            return
+
+        return {
+            "name": _("Paired Payment"),
+            "type": "ir.actions.act_window",
+            "res_model": "account.payment",
+            "view_mode": "form",
+            "res_id": self.paired_internal_transfer_payment_id.id,
+            "target": "current",
+        }

--- a/account_internal_transfer/views/account_payment_views.xml
+++ b/account_internal_transfer/views/account_payment_views.xml
@@ -26,6 +26,9 @@
         <field name="model">account.payment</field>
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <field name="show_warning" invisible="not show_warning"/>
+            </xpath>
             <xpath expr="//group[@name='main_group']/group[@name='group1']/field[@name='payment_type']" position="before">
                 <label for="is_internal_transfer" invisible="not is_internal_transfer"/>
                 <div invisible="not is_internal_transfer">


### PR DESCRIPTION
In a transfer between a journal in main currency and one in secondary currency, the amount field in the journal entry for the main currency journal must be adjusted so it is recorded in the main currency, not in the secondary currency. This commit fixes that behavior.