### PR TITLE
[FIX] account_ux: call _post instead of action_post

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -20,9 +20,9 @@ class AccountMove(models.Model):
     def delete_number(self):
         self.filtered(lambda x: x.state == "cancel").write({"name": "/"})
 
-    def action_post(self):
+    def _post(self, soft=True):
         """After validate invoice will sent an email to the partner if the related journal has mail_template_id set"""
-        res = super().action_post()
+        res = super()._post(soft=soft)
         self.action_send_invoice_mail()
         return res
 


### PR DESCRIPTION
Use _post instead of action_post to ensure that is called also when confirming multiple entries at once. action_post calls _post internally, so it doesn't change the current behavior when confirming a single entry.