### PR TITLE
[FIX] account_ux: fix uninstall hook

### DIFF
--- a/account_ux/hooks.py
+++ b/account_ux/hooks.py
@@ -8,6 +8,6 @@ def _revert_method(cls, name):
     setattr(cls, name, method.origin)
 
 
-def uninstall_hook(cr, registry):
+def uninstall_hook(env):
     _revert_method(AccountPayment, "_compute_available_journal_ids")
     _revert_method(AccountMove, "_compute_show_reset_to_draft_button")


### PR DESCRIPTION
In Odoo 19.0, hooks are called with env instead of the old cr, registry pattern.