### PR TITLE
[IMP] account_ux: mark payment as sent from email wizard

### DIFF
--- a/account_ux/wizards/__init__.py
+++ b/account_ux/wizards/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import account_change_currency
 from . import res_config_settings
+from . import mail_compose_message

--- a/account_ux/wizards/mail_compose_message.py
+++ b/account_ux/wizards/mail_compose_message.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class MailComposer(models.TransientModel):
+    _inherit = "mail.compose.message"
+
+    def _action_send_mail(self, auto_commit=False):
+        result_mails_su, result_messages = super()._action_send_mail(auto_commit=auto_commit)
+
+        for wizard in self:
+            res_ids = wizard._evaluate_res_ids()
+
+            if wizard.model == "account.payment":
+                self.env["account.payment"].browse(res_ids).write({"is_move_sent": True})
+
+        return result_mails_su, result_messages


### PR DESCRIPTION
When sending payment emails using the mail compose message wizard, it is useful to mark the payment as sent automatically once the email is sent. This commit introduces a feature that allows users to mark the payment as sent directly from the email wizard, streamlining the workflow and reducing manual steps.