### PR TITLE
[IMP] account_ux: Add account_background_post as a dependency

### DIFF
--- a/account_ux/__manifest__.py
+++ b/account_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account UX",
-    "version": "19.0.1.4.0",
+    "version": "19.0.1.5.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",
@@ -28,7 +28,7 @@
     "license": "AGPL-3",
     "images": [],
     "depends": [
-        "account",
+        "account_background_post",
         "sale",
         "base_vat",
         "account_debit_note",

--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -60,6 +60,12 @@ class AccountMove(models.Model):
                     body_is_html=True,
                 )
 
+    def _get_mail_template(self):
+        res = super()._get_mail_template()
+        if self.journal_id.mail_template_id:
+            res = self.journal_id.mail_template_id
+        return res
+
     @api.onchange("partner_id")
     def _onchange_partner_commercial(self):
         if self.partner_id.user_id:


### PR DESCRIPTION
Keep this as a dependency because background post
is being modified to always post invoices using action_post. This is required for several reasons, including ensuring invoices are sent automatically when the journal is configured to do so.