### PR TITLE
[IMP] account_ux: Refresh currency rate on invoice posting

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -22,6 +22,12 @@ class AccountMove(models.Model):
 
     def action_post(self):
         """After validate invoice will sent an email to the partner if the related journal has mail_template_id set"""
+
+        # Refresh the currency rate if no invoice date is set and the currency is different from company currency
+        for move in self:
+            if not move.invoice_date and move.currency_id != move.company_id.currency_id:
+                move.refresh_invoice_currency_rate()
+
         # Use action_post to ensure the mail is sent only when the move is posted
         res = super().action_post()
         self.action_send_invoice_mail()


### PR DESCRIPTION
When posting an invoice without an invoice date and with a currency different from the company currency, the currency rate is now refreshed to ensure accurate conversion.