### PR TITLE
[FIX] account_ux: Fix invoice email send to create PDF attachment with  res_field

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -28,23 +28,19 @@ class AccountMove(models.Model):
         return res
 
     def action_send_invoice_mail(self):
+        move_send = self.env["account.move.send"]
         for rec in self.filtered(lambda x: x.is_invoice(include_receipts=True) and x.journal_id.mail_template_id):
             if rec.partner_id.email:
                 try:
-                    rec.message_post_with_source(rec.journal_id.mail_template_id, subtype_xmlid="mail.mt_comment")
+                    move_send._generate_and_send_invoices(
+                        rec,
+                        allow_raising=False,
+                        sending_methods={"email"},
+                        mail_template=rec.journal_id.mail_template_id,
+                    )
                     rec.is_move_sent = True
                 except Exception as error:
                     title = _("ERROR: Invoice was not sent via email")
-                    # message = _(
-                    #     "Invoice %s was correctly validate but was not send"
-                    #     " via email. Please review invoice chatter for more"
-                    #     " information" % rec.display_name
-                    # )
-                    # self.env.user.notify_warning(
-                    #     title=title,
-                    #     message=message,
-                    #     sticky=True,
-                    # )
                     rec.message_post(
                         body="<br/><br/>".join(
                             [


### PR DESCRIPTION

Use account.move.send pipeline when auto-sending invoices on post so the generated PDF is stored in invoice_pdf_report_file (res_field set correctly). This aligns the auto-send flow with standard invoice document generation and attachment linking.