### PR TITLE
[IMP] account_ux: always allow to recompute taxes

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -243,3 +243,15 @@ class AccountMove(models.Model):
         # TODO v20: Check if we still need this workaround.
         job_count = 1
         super()._cron_account_move_send(job_count=job_count)
+
+    @api.onchange("fiscal_position_id")
+    def _onchange_fiscal_position_id(self):
+        """
+        Hacemos similar a sale_ux, cambiar FP re-computa automáticamente impuestos.
+        No llamamos a action_update_fpos_values() porque hace más cosas y lo queremos matener mínimo similar a sale_ux
+        """
+        self.ensure_one()
+        lines_to_recompute = self.invoice_line_ids.filtered(
+            lambda line: line.display_type not in ("line_section", "line_note")
+        )
+        lines_to_recompute._compute_tax_ids()

--- a/account_ux/views/account_move_views.xml
+++ b/account_ux/views/account_move_views.xml
@@ -20,6 +20,11 @@
                 <attribute name="optional">hide if parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] else show</attribute>
             </field>
 
+            <!-- lo dejamos siempre visible para que si el cliente modifica cosas por edicion masiva, expo/impo u otras o manualmente, pueda siempre re-computar según la FP -->
+            <button name="action_update_fpos_values" position="attributes">
+                <attribute name="invisible">state in ['cancel', 'posted']</attribute>
+            </button>
+
             <button name="button_draft" position="after">
                 <button name="delete_number" string="Delete Number" invisible="state != 'cancel' or not name or name == '/'" type="object" help="Deleting the number will allow you to delete this invoice or to get a new number if you re-validate it. If this invoice represents a voided invoice, then you should not clean it." confirm="Warning! This can't be undone. Deleting the number will allow you to delete this invoice or to get a new number if you re-validate it. If this invoice represents a voided invoice, then you should not clean it. Do you want to continue?" groups="account.group_account_manager"/>
             </button>


### PR DESCRIPTION
El boton no molesta y puede ser util en escenarios donde no se recomputa automaticamente (por ej. si usuario cambio manualmente taxes y quiere corregir, si e edito fiscal position por shell u otro metodo que no llama onchange)