### PR TITLE
[IMP] account_ux: Hide account move receipt options

### DIFF
--- a/account_ux/views/account_move_views.xml
+++ b/account_ux/views/account_move_views.xml
@@ -115,6 +115,12 @@
                 <button name="%(action_account_change_currency)d" type="action" invisible="state != 'draft'" icon="fa-exchange" class="btn-link" title="Change Currency and Rate" groups="base.group_multi_currency"/>
             </xpath>
 
+
+            <!-- Hide the bill/receipt selector widget -->
+            <xpath expr="//div[hasclass('oe_title')]/span[hasclass('o_form_label')][field[@name='move_type'][@widget='receipt_selector']]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+
         </field>
     </record>
 

--- a/account_ux/views/res_config_settings_views.xml
+++ b/account_ux/views/res_config_settings_views.xml
@@ -9,6 +9,9 @@
                 <attribute name="confirm">The accounting plan will be reloaded, creating accounts, taxes, and other records that may be missing. It is recommended to perform this action in a testing environment before implementing it in production to avoid potential inconsistencies
                 </attribute>
             </xpath>
+            <xpath expr="//setting[@id='show_sale_receipts']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
- Hide bill/receipt selector in account move form view
- Hide "Show Sale Receipts" setting in settings