### PR TITLE
[ADD] account_fci_interests: FCI withdrawal with accrued interest journal entry

### DIFF
--- a/account_fci_interests/__init__.py
+++ b/account_fci_interests/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_fci_interests/__manifest__.py
+++ b/account_fci_interests/__manifest__.py
@@ -1,0 +1,40 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "FCI Interests Management",
+    "version": "19.0.1.0.0",
+    "category": "Accounting",
+    "sequence": 14,
+    "summary": "Manage Mutual Investment Funds (FCI) withdrawals with accrued interest accounting",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "account_internal_transfer",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/account_journal_views.xml",
+        "views/account_payment_views.xml",
+        "views/account_journal_dashboard_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/account_fci_interests/i18n/es.po
+++ b/account_fci_interests/i18n/es.po
@@ -1,0 +1,69 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * account_fci_interests
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2024-01-01 00:00+0000\n"
+"Last-Translator: ADHOC SA <info@adhoc.com.ar>\n"
+"Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_fci_interests
+#: model:ir.model.fields,field_description:account_fci_interests.field_account_journal__is_fci_journal
+msgid "Is FCI Journal"
+msgstr "Registra FCI"
+
+#. module: account_fci_interests
+#: model:ir.model.fields,field_description:account_fci_interests.field_account_journal__fci_income_account_id
+msgid "FCI Income Account"
+msgstr "Cuenta de ingreso por intereses"
+
+#. module: account_fci_interests
+#: model:ir.model.fields,field_description:account_fci_interests.field_account_payment__fci_interest_rate
+msgid "Accrued Interest Rate (%)"
+msgstr "Tasa de interés devengada (%)"
+
+#. module: account_fci_interests
+#: model:ir.model.fields,field_description:account_fci_interests.field_account_payment__is_fci_payment
+msgid "Is FCI Payment"
+msgstr "Es pago de FCI"
+
+#. module: account_fci_interests
+#: model:ir.ui.view,arch_db:account_fci_interests.account_journal_dashboard_kanban_view_fci
+msgid "Withdraw FCI / Accrue Interest"
+msgstr "Rescatar FCI / Devengar Intereses"
+
+#. module: account_fci_interests
+#: code:addons/account_fci_interests/models/account_payment.py:0
+#, python-format
+msgid "FCI Accrued Interest"
+msgstr "Intereses devengados FCI"
+
+#. module: account_fci_interests
+#: code:addons/account_fci_interests/models/account_journal.py:0
+#, python-format
+msgid ""
+"Journal '%(name)s' is marked as FCI Journal but is not of type 'Cash'. "
+"An FCI journal must be of type Cash."
+msgstr ""
+"El diario '%(name)s' está marcado como Diario FCI pero no es de tipo 'Efectivo'. "
+"Un diario FCI debe ser de tipo Efectivo."
+
+#. module: account_fci_interests
+#: code:addons/account_fci_interests/models/account_payment.py:0
+#, python-format
+msgid ""
+"Journal '%(journal)s' is an FCI journal but does not have an Income Account "
+"configured. Please set the 'FCI Income Account' on the journal before "
+"registering accrued interest."
+msgstr ""
+"El diario '%(journal)s' es un diario FCI pero no tiene configurada una Cuenta de Ingresos. "
+"Por favor configure la 'Cuenta de ingreso por intereses' en el diario antes de registrar intereses devengados."

--- a/account_fci_interests/models/__init__.py
+++ b/account_fci_interests/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_journal, account_payment

--- a/account_fci_interests/models/account_journal.py
+++ b/account_fci_interests/models/account_journal.py
@@ -1,0 +1,66 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    is_fci_journal = fields.Boolean(
+        string="Is FCI Journal",
+        default=False,
+        help="If enabled, this journal is used to manage a Mutual Investment Fund (FCI).",
+    )
+    fci_income_account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="FCI Income Account",
+        domain="[('internal_group', '=', 'income')]",
+        check_company=True,
+        help="Income account used to record accrued interest on FCI withdrawals.",
+    )
+
+    @api.constrains("is_fci_journal", "type")
+    def _check_fci_journal_type(self):
+        for journal in self:
+            if journal.is_fci_journal and journal.type != "cash":
+                raise ValidationError(
+                    _(
+                        "Journal '%(name)s' is marked as FCI Journal but is not of type 'Cash'. "
+                        "An FCI journal must be of type Cash.",
+                        name=journal.display_name,
+                    )
+                )
+
+    def action_fci_withdraw(self):
+        """Open a pre-filled internal transfer form from this FCI journal."""
+        self.ensure_one()
+        return {
+            "name": _("Withdraw FCI / Accrue Interest"),
+            "type": "ir.actions.act_window",
+            "res_model": "account.payment",
+            "view_mode": "form",
+            "target": "current",
+            "context": {
+                "default_is_internal_transfer": True,
+                "default_journal_id": self.id,
+                "default_payment_type": "outbound",
+            },
+        }

--- a/account_fci_interests/models/account_payment.py
+++ b/account_fci_interests/models/account_payment.py
@@ -1,0 +1,103 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from odoo import _, api, fields, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    fci_interest_amount = fields.Monetary(
+        string="Accrued Interest Amount",
+        default=0.0,
+        help="Fixed interest amount to accrue on FCI withdrawal.",
+        currency_field="currency_id",
+    )
+
+    # Computed helper field used to show/hide the interest field in the view
+    is_fci_payment = fields.Boolean(
+        string="Is FCI Payment",
+        compute="_compute_is_fci_payment",
+    )
+
+    @api.depends("destination_journal_id", "destination_journal_id.is_fci_journal")
+    def _compute_is_fci_payment(self):
+        for payment in self:
+            payment.is_fci_payment = payment.journal_id.is_fci_journal
+
+    def _prepare_move_lines_per_type(self, write_off_line_vals=None, force_balance=None):
+        """
+        Override to inject an interest line when the destination journal is an FCI journal
+        and the fci_interest_rate is set.
+
+        Expected journal entry for an FCI withdrawal (outbound transfer to FCI):
+          - Bank line (origin):      Credit total amount  (e.g. 1,015,000)
+          - FCI line (destination):  Debit  capital amount (amount - interest, e.g. 1,000,000)
+          - Interest line:           Credit interest amount using fci_income_account_id (e.g. 15,000)
+        """
+        self.ensure_one()
+
+        # Build a write-off line for the interest amount when applicable
+        extra_write_off = list(write_off_line_vals) if write_off_line_vals else []
+
+        if (
+            self.journal_id.is_fci_journal
+            and self.payment_type == "outbound"
+            and not self.paired_internal_transfer_payment_id
+            and self.fci_interest_amount > 0.0
+        ):
+            interest_amount_currency = -self.fci_interest_amount
+            interest_balance = self.currency_id._convert(
+                interest_amount_currency,
+                self.company_id.currency_id,
+                self.company_id,
+                self.date,
+            )
+            extra_write_off.append(
+                {
+                    "name": _("FCI Accrued Interest"),
+                    "account_id": self.journal_id.fci_income_account_id.id,
+                    "partner_id": self.partner_id.id,
+                    "currency_id": self.currency_id.id,
+                    "amount_currency": interest_amount_currency,
+                    "balance": interest_balance,
+                }
+            )
+
+        return super()._prepare_move_lines_per_type(
+            write_off_line_vals=extra_write_off or None,
+            force_balance=force_balance,
+        )
+
+    def _generate_journal_entry(self, write_off_line_vals=None):
+        """
+        Override to bypass the automatic reconciliation of the interest line when it's an FCI payment.
+        This is needed to keep the interest line open (unreconciled) until the end of the period, when it will be reconciled with a manual journal entry.
+        """
+        move_vals = super()._generate_journal_entry(write_off_line_vals=write_off_line_vals)
+
+        if self.paired_internal_transfer_payment_id.is_fci_payment:
+            # Adjust the payment amount to include the FCI interest from the paired payment
+            self.amount = (
+                self.paired_internal_transfer_payment_id.amount
+                + self.paired_internal_transfer_payment_id.fci_interest_amount
+            )
+
+        return move_vals

--- a/account_fci_interests/security/ir.model.access.csv
+++ b/account_fci_interests/security/ir.model.access.csv
@@ -1,0 +1,1 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink

--- a/account_fci_interests/tests/__init__.py
+++ b/account_fci_interests/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_fci_transfer

--- a/account_fci_interests/tests/test_fci_transfer.py
+++ b/account_fci_interests/tests/test_fci_transfer.py
@@ -1,0 +1,165 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.tests.common import TransactionCase
+
+
+class TestFCITransfer(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        company = self.env.company
+
+        self.fci_income_account = self.env["account.account"].create(
+            {
+                "name": "FCI Interest Income",
+                "code": "FCI.INC.001",
+                "account_type": "income",
+                "company_ids": [company.id],
+            }
+        )
+
+        self.bank_journal = self.env["account.journal"].create(
+            {
+                "name": "Test Bank",
+                "code": "BANK",
+                "type": "bank",
+                "company_id": company.id,
+            }
+        )
+        # Ensure the bank journal has payment accounts configured for internal transfers
+        self.bank_journal.outbound_payment_method_line_ids.payment_account_id = self.bank_journal.default_account_id
+        self.bank_journal.inbound_payment_method_line_ids.payment_account_id = self.bank_journal.default_account_id
+
+        self.fci_journal = self.env["account.journal"].create(
+            {
+                "name": "Test FCI Fund",
+                "code": "FCI",
+                "type": "cash",
+                "company_id": company.id,
+                "is_fci_journal": True,
+                "fci_income_account_id": self.fci_income_account.id,
+            }
+        )
+        # The outstanding account is required on payment method lines for internal transfers
+        # Use the journal's own default account (created automatically with the journal)
+        self.fci_journal.outbound_payment_method_line_ids.payment_account_id = self.fci_journal.default_account_id
+
+        self.fci_journal.inbound_payment_method_line_ids.payment_account_id = self.fci_journal.default_account_id
+
+    def _create_transfer(self, from_journal, to_journal, amount, interest=0.0):
+        """Helper: create and post an internal transfer between two journals."""
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": from_journal.id,
+                "destination_journal_id": to_journal.id,
+                "is_internal_transfer": True,
+                "payment_type": "outbound",
+                "partner_id": self.env.company.partner_id.id,
+                "amount": amount,
+                "fci_interest_amount": interest,
+                "payment_method_line_id": from_journal.outbound_payment_method_line_ids[:1].id,
+            }
+        )
+        payment.action_post()
+        return payment
+
+    def test_inbound_to_fci_no_interest_lines(self):
+        """
+        Transfer FROM bank TO fci_journal (destination_journal_id = fci_journal).
+
+        The interest line must NOT appear in either move:
+          - move_id of the original payment (bank → FCI)
+          - move_id of the paired payment generated after posting
+        """
+        amount = 500_000.0
+        payment = self._create_transfer(
+            from_journal=self.bank_journal,
+            to_journal=self.fci_journal,
+            amount=amount,
+            interest=10000.0,  # interest set, but must be ignored because journal_id is not FCI
+        )
+
+        # Original payment move: no interest line
+        move = payment.move_id
+        self.assertEqual(move.state, "posted")
+        interest_lines = move.line_ids.filtered(lambda line: line.account_id == self.fci_income_account)
+        self.assertFalse(interest_lines, "No interest line expected on the inbound-to-FCI move")
+
+        # Paired payment move: no interest line either
+        paired = payment.paired_internal_transfer_payment_id
+        self.assertTrue(paired, "A paired payment must exist after posting")
+        paired_interest_lines = paired.move_id.line_ids.filtered(
+            lambda line: line.account_id == self.fci_income_account
+        )
+        self.assertFalse(
+            paired_interest_lines,
+            "No interest line expected on the paired payment move",
+        )
+
+    def test_outbound_from_fci_interest_line(self):
+        """
+        Transfer FROM fci_journal TO bank (journal_id = fci_journal, outbound).
+
+        Expected move on the FCI payment (journal_id.is_fci_journal = True):
+          - 3 lines total
+          - Debit  = amount          (liquidity line, FCI account)
+          - Credit = amount - interest  (counterpart — capital returned)
+          - Credit = interest           (fci_income_account_id — accrued interest)
+          - Move is balanced
+
+        The paired payment (bank side) must NOT have an interest line.
+        """
+        amount = 1000000.0
+        interest = 15000.0
+        capital = amount + interest  # 1,015,000
+
+        payment = self._create_transfer(
+            from_journal=self.fci_journal,
+            to_journal=self.bank_journal,
+            amount=amount,
+            interest=interest,
+        )
+
+        # --- Original FCI payment move ---
+        move = payment.move_id
+        self.assertEqual(move.state, "posted")
+        self.assertEqual(len(move.line_ids), 3, "FCI move must have exactly 3 lines")
+
+        interest_line = move.line_ids.filtered(lambda line: line.account_id == self.fci_income_account)
+        self.assertEqual(len(interest_line), 1, "Exactly one interest line expected")
+        self.assertAlmostEqual(interest_line.credit, interest, places=2)
+        self.assertAlmostEqual(interest_line.debit, 0.0, places=2)
+
+        journal_account_line = move.line_ids.filtered(
+            lambda line: line.account_id == payment.journal_id.default_account_id
+        )
+
+        counterpart_line = move.line_ids.filtered(
+            lambda line: (
+                line.account_id != self.fci_income_account and line.account_id != payment.journal_id.default_account_id
+            )
+        )
+        self.assertAlmostEqual(journal_account_line.credit, amount, places=2)
+        self.assertAlmostEqual(counterpart_line.debit, capital, places=2)
+
+        total_debit = sum(move.line_ids.mapped("debit"))
+        total_credit = sum(move.line_ids.mapped("credit"))
+        self.assertAlmostEqual(total_debit, total_credit, places=2)
+
+        # --- Paired payment move (bank side) must NOT have interest line ---
+        paired = payment.paired_internal_transfer_payment_id
+        self.assertTrue(paired, "A paired payment must exist after posting")
+        paired_interest_lines = paired.move_id.line_ids.filtered(
+            lambda line: line.account_id == self.fci_income_account
+        )
+        self.assertFalse(
+            paired_interest_lines,
+            "No interest line expected on the paired (bank) payment move",
+        )
+        self.assertAlmostEqual(
+            paired.amount,
+            capital,
+            places=2,
+            msg="Paired payment amount must equal capital (amount + interest)",
+        )

--- a/account_fci_interests/views/account_journal_dashboard_views.xml
+++ b/account_fci_interests/views/account_journal_dashboard_views.xml
@@ -1,0 +1,44 @@
+<odoo>
+    <record id="account_journal_dashboard_kanban_view_fci" model="ir.ui.view">
+        <field name="name">account.journal.dashboard.kanban.fci</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.account_journal_dashboard_kanban_view"/>
+        <field name="arch" type="xml">
+            <!-- Load the is_fci_journal field into the kanban card -->
+            <field name="type" position="after">
+                <field name="is_fci_journal"/>
+            </field>
+
+            <!--
+                Add a "Withdraw FCI / Accrue Interest" button in the kanban card body.
+                Injected at the end of the main card <t t-name="card"> template,
+                visible only when the journal is flagged as FCI.
+            -->
+            <xpath expr="//t[@t-name='card']" position="inside">
+                <t t-if="record.is_fci_journal.raw_value">
+                    <div class="row mt-2">
+                        <div class="col-12">
+                            <button
+                                type="object"
+                                name="action_fci_withdraw"
+                                class="btn-primary"
+                                groups="account.group_account_user">
+                                Withdraw FCI / Accrue Interest
+                            </button>
+                        </div>
+                    </div>
+                </t>
+            </xpath>
+
+            <!--
+                Add the FCI withdraw option in the kanban card menu (gear icon),
+                in the "New" section for bank/cash journals.
+            -->
+            <div name="kanban_manage_new" position="inside">
+                <div t-if="record.is_fci_journal.raw_value" groups="account.group_account_user">
+                    <a role="menuitem" type="object" name="action_fci_withdraw">Withdraw FCI / Accrue Interest</a>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/account_fci_interests/views/account_journal_views.xml
+++ b/account_fci_interests/views/account_journal_views.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <record id="view_account_journal_form_fci" model="ir.ui.view">
+        <field name="name">account.journal.form.fci</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <!-- Inject FCI fields after the loss_account_id field on the Journal Entries tab -->
+            <field name="loss_account_id" position="after">
+                <field name="is_fci_journal"
+                       invisible="type != 'cash'"
+                       groups="account.group_account_user"/>
+                <field name="fci_income_account_id"
+                       invisible="not is_fci_journal"
+                       required="is_fci_journal"
+                       groups="account.group_account_user"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/account_fci_interests/views/account_payment_views.xml
+++ b/account_fci_interests/views/account_payment_views.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <record id="view_account_payment_form_fci" model="ir.ui.view">
+        <field name="name">account.payment.form.fci</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
+            <!--
+                Inject the fci_interest_rate field into the payment form.
+                It is visible only when the journal is an FCI journal.
+                We also load the is_fci_payment computed field (invisible) to drive visibility.
+            -->
+            <field name="paired_internal_transfer_payment_id" position="after">
+                <field name="is_fci_payment" invisible="1"/>
+            </field>
+            <field name="memo" position="after">
+                <field name="fci_interest_amount"
+                       invisible="not is_fci_payment or payment_type != 'outbound'"
+                       groups="account.group_account_user"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION

Adds a new module to manage Mutual Investment Fund (FCI) withdrawals with automatic accrued interest accounting.

Features
-New boolean field [is_fci_journal] on account.journal (cash journals only) to mark a journal as an FCI fund.

-New field [fci_income_account_id] on account.journal to configure the income account where accrued interest is posted.

-New field [fci_interest_amount] on account.payment to specify a fixed interest amount on withdrawal.

-When an internal transfer is posted from an FCI journal ([journal_id.is_fci_journal = True]) and a paired transfer payment exists, a third line is automatically injected into the journal entry crediting the configured income account for the accrued interest amount.
Dashboard button on FCI kanban cards to quickly register a withdrawal.