### PR TITLE
[FIX] account_internal_transfer: show warning only in draft/cancelled state

### DIFF
--- a/account_internal_transfer/models/account_payment.py
+++ b/account_internal_transfer/models/account_payment.py
@@ -257,7 +257,12 @@ class AccountPayment(models.Model):
     def _compute_show_warning(self):
         for pay in self:
             paired_pay = pay.paired_internal_transfer_payment_id
-            if pay.is_internal_transfer and paired_pay and paired_pay.state != pay.state:
+            if (
+                pay.is_internal_transfer
+                and paired_pay
+                and paired_pay.state != pay.state
+                and (pay.state in ["draft", "canceled"] or paired_pay.state in ["draft", "canceled"])
+            ):
                 state_labels = dict(pay._fields["state"]._description_selection(pay.env))
                 base_url = pay.env["ir.config_parameter"].sudo().get_param("web.base.url")
                 action_url = f"{base_url}/web#id={paired_pay.id}&model=account.payment&view_type=form"


### PR DESCRIPTION
If one of the payments of the internal transfer is in 'draft' or 'canceled' state, we want to show the warning message to the user. In other states, it can be confusing to have the warning message displayed, especially if the payments are already posted.