### PR TITLE
[FIX] account_ux: add shared_to_branches to account.reconcile.model

### DIFF
--- a/account_ux/models/__init__.py
+++ b/account_ux/models/__init__.py
@@ -15,3 +15,4 @@ from . import account_payment
 from . import account_tax
 from . import account_fiscal_position
 from . import account_payment_method_line
+from . import account_reconcile_model

--- a/account_ux/models/account_reconcile_model.py
+++ b/account_ux/models/account_reconcile_model.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class AccountReconcileModel(models.Model):
+    _inherit = "account.reconcile.model"
+
+    shared_to_branches = fields.Boolean(
+        related="match_journal_ids.shared_to_branches",
+        store=True,
+    )


### PR DESCRIPTION
This prevents domain errors when shared_to_branches is referenced from flows where the field was previously missing (e.g. account.bank.statement.line fee model creation in _create_account_model_fee).