### PR TITLE
[IMP] account_internal_transfer: prevent selecting the same source and destination journal

### DIFF
--- a/account_internal_transfer/models/account_payment.py
+++ b/account_internal_transfer/models/account_payment.py
@@ -45,16 +45,19 @@ class AccountPayment(models.Model):
         for rec in self:
             rec.destination_journal_domain = Domain(
                 rec.env["account.journal"]._check_company_domain(rec.destination_company_id)
-            ) & Domain([("type", "in", ("bank", "cash", "credit")), ("id", "!=", rec.journal_id.id)])
+            ) & Domain([("type", "in", ("bank", "cash", "credit"))])
 
     @api.constrains("destination_company_id", "destination_journal_id")
     def _check_journal_company(self):
         for rec in self.filtered("destination_journal_id"):
             # Force recompute of the domain to ensure it's up to date
             rec._compute_destination_journal_domain()
+            has_cashbox_field = "cashbox_session_id" in rec._fields
+            if (not has_cashbox_field or not rec.cashbox_session_id) and rec.destination_journal_id == rec.journal_id:
+                raise ValidationError(_("The destination journal must be different from the source journal."))
             if rec.destination_journal_id not in rec.env["account.journal"].search(rec.destination_journal_domain):
                 raise ValidationError(
-                    "The selected 'Destination Journal' does not belong to the selected destination company."
+                    _("The selected 'Destination Journal' does not belong to the selected destination company.")
                 )
 
     @api.depends("company_id")


### PR DESCRIPTION

Add a constraint to block internal transfers when the destination journal is the same as the source journal.

This ensures transfer integrity and provides a clear validation error message to the user.