### PR TITLE
[FIX] account_journal_security: avoid test crash if multi-store ir.rule is present

### DIFF
--- a/account_journal_security/tests/test_account_journal_security.py
+++ b/account_journal_security/tests/test_account_journal_security.py
@@ -6,13 +6,18 @@ from odoo.exceptions import AccessError
 class TestAccountJournalSecurity(common.TransactionCase):
     def setUp(self):
         super().setUp()
+        # If account_multi_store is installed but its fields are not yet registered
+        # (happens when tests run before account_multi_store loads in the sequence),
+        # deactivate its ir.rules temporarily to avoid interference.
+        if "store_id" not in self.env["account.journal"]._fields:
+            self.env["ir.rule"].sudo().search([("name", "ilike", "multi-store")]).write({"active": False})
         self.today = fields.Date.today()
-        self.first_company = self.env["res.company"].search([], limit=1)
+        self.first_company = self.env.ref("base.main_company")
         self.company_bank_journal = self.env["account.journal"].search(
             [("company_id", "=", self.first_company.id), ("type", "=", "bank")], limit=1
         )
 
-        self.user_admin = self.env.ref("base.default_user")
+        self.user_admin = self.env.ref("base.user_admin")
         self.user_admin.write({"company_ids": [(4, self.first_company.id)]})
         self.user_demo = self.env.ref("base.user_demo")
 


### PR DESCRIPTION

Technical:
Workaround for Odoo 18+ where a global ir.rule from account_multi_store references account.journal.store_id, but the field is not yet registered when account_journal_security tests run (due to module load order). In setUp, if 'store_id' is not in account.journal._fields, all ir.rules with 'multi-store' in the name are temporarily deactivated to prevent ValueError during test execution. This does not affect production usage, only test runs where account_multi_store is installed but not yet loaded.

Change note:
Evita que los tests de account_journal_security fallen con ValueError cuando está instalado account_multi_store pero aún no cargó el campo store_id. Se desactivan temporalmente las reglas de multi-store en setUp si el campo no existe, evitando el crash de los tests por el orden de carga de módulos.