### PR TITLE
[FIX] account_ux: Recompute tax totals only for posted invoices/receipts

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -178,7 +178,7 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         super()._compute_tax_totals()
 
-        for move in self.filtered(lambda x: x.state == "posted"):
+        for move in self.filtered(lambda x: x.state == "posted" and x.is_invoice(include_receipts=True)):
             base_lines, _tax_lines = move._get_rounded_base_and_tax_lines()
 
             # Detectar si hay impuestos inactivos en las líneas de impuestos


### PR DESCRIPTION
When computing tax totals, we should only recompute them for posted invoices/receipts, as they are the only ones that can have inactive taxes. This avoids unnecessary computations for other types of moves or for draft moves