### PR TITLE
[IMP] account_internal_transfer: sync draft/canceled state in paired …

### DIFF
--- a/account_internal_transfer/__manifest__.py
+++ b/account_internal_transfer/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Internal Transfer",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_internal_transfer/models/account_payment.py
+++ b/account_internal_transfer/models/account_payment.py
@@ -1,4 +1,3 @@
-from markupsafe import Markup, escape
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
@@ -30,7 +29,6 @@ class AccountPayment(models.Model):
         compute="_compute_main_company",
     )
     available_partner_bank_ids = fields.Many2many(compute_sudo=True)
-    show_warning = fields.Html(compute="_compute_show_warning")
 
     @api.depends("company_id", "is_internal_transfer")
     def _compute_destination_company_id(self):
@@ -272,38 +270,6 @@ class AccountPayment(models.Model):
                 paired_payment.with_context(skip_paired_payment_update=True).write(updates)
 
         return res
-
-    @api.depends("state", "paired_internal_transfer_payment_id.state")
-    def _compute_show_warning(self):
-        for pay in self:
-            paired_pay = pay.paired_internal_transfer_payment_id
-            if (
-                pay.is_internal_transfer
-                and paired_pay
-                and paired_pay.state != pay.state
-                and (pay.state in ["draft", "canceled"] or paired_pay.state in ["draft", "canceled"])
-            ):
-                state_labels = dict(pay._fields["state"]._description_selection(pay.env))
-                base_url = pay.env["ir.config_parameter"].sudo().get_param("web.base.url")
-                action_url = f"{base_url}/web#id={paired_pay.id}&model=account.payment&view_type=form"
-                # Escape all dynamic values to prevent XSS
-                pay_state = escape(state_labels.get(pay.state, pay.state))
-                paired_state = escape(state_labels.get(paired_pay.state, paired_pay.state))
-                safe_url = escape(action_url)
-                pay.show_warning = Markup(
-                    _(
-                        '<div class="alert alert-warning" role="alert">'
-                        '<i class="fa fa-exclamation-triangle"></i> '
-                        "This payment is in <strong>%s</strong> state but the paired one is in <strong>%s</strong> state. "
-                        "Ensure both are in the same state when finished making changes. "
-                        '<a href="%s" class="btn btn-sm btn-warning" style="margin-left: 10px;">'
-                        '<i class="fa fa-external-link"></i> Go to Paired Payment'
-                        "</a>"
-                        "</div>"
-                    )
-                ) % (pay_state, paired_state, safe_url)
-            else:
-                pay.show_warning = ""
 
     def action_open_paired_payment(self):
         """Navigate to the paired internal transfer payment."""

--- a/account_internal_transfer/models/account_payment.py
+++ b/account_internal_transfer/models/account_payment.py
@@ -319,3 +319,33 @@ class AccountPayment(models.Model):
             "res_id": self.paired_internal_transfer_payment_id.id,
             "target": "current",
         }
+
+    def action_draft(self):
+        res = super().action_draft()
+        if self.env.context.get("skip_paired_sync"):
+            return res
+        paired = self.filtered(
+            lambda p: (
+                p.is_internal_transfer
+                and p.paired_internal_transfer_payment_id
+                and p.paired_internal_transfer_payment_id.state != "draft"
+            )
+        ).mapped("paired_internal_transfer_payment_id")
+        if paired:
+            paired.with_context(skip_paired_sync=True).action_draft()
+        return res
+
+    def action_cancel(self):
+        res = super().action_cancel()
+        if self.env.context.get("skip_paired_sync"):
+            return res
+        paired = self.filtered(
+            lambda p: (
+                p.is_internal_transfer
+                and p.paired_internal_transfer_payment_id
+                and p.paired_internal_transfer_payment_id.state != "canceled"
+            )
+        ).mapped("paired_internal_transfer_payment_id")
+        if paired:
+            paired.with_context(skip_paired_sync=True).action_cancel()
+        return res

--- a/account_internal_transfer/views/account_payment_views.xml
+++ b/account_internal_transfer/views/account_payment_views.xml
@@ -26,9 +26,6 @@
         <field name="model">account.payment</field>
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet" position="before">
-                <field name="show_warning" invisible="not show_warning"/>
-            </xpath>
             <xpath expr="//group[@name='main_group']/group[@name='group1']/field[@name='payment_type']" position="before">
                 <label for="is_internal_transfer" invisible="not is_internal_transfer"/>
                 <div invisible="not is_internal_transfer">


### PR DESCRIPTION
…internal transfer payments

Implement automatic synchronization of the draft and canceled states between both payments of an internal transfer (third-party checks). Overrides action_draft and action_cancel to ensure that when one payment is set to draft or canceled, its paired payment is also updated accordingly. A context guard (skip_paired_sync) is used to prevent infinite recursion during the sync process.

Change note:
Sincronización automática de los estados "borrador" y "cancelado" entre ambos pagos de una transferencia interna (cheques de terceros). Ahora, al cambiar el estado de uno de los pagos a borrador o cancelado, el pago vinculado se actualiza automáticamente para mantener la coherencia. Esta mejora evita inconsistencias y reduce errores operativos en la gestión de transferencias internas.