### PR TITLE
[ADD] account_ux: add constraint to prevent journal change on posted moves

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -241,3 +241,10 @@ class AccountMove(models.Model):
                 "default_action": "change_partner",
             },
         }
+
+    @api.constrains("journal_id")
+    def _check_journal(self):
+        """Check that the journal and the allows to post in the move's company."""
+        for move in self:
+            if move.state == "posted":
+                raise UserError(_("You cannot change the journal of a posted move (%s).") % move.display_name)


### PR DESCRIPTION

- Added `_check_journal_company` constrains method to `AccountMove` model
- Raises `UserError` when attempting to modify the journal of a move in state 'posted'

Change note: Se agregó una validación que impide cambiar el diario de un asiento contable que ya se encuentra confirmado (publicado). Si se intenta modificar el diario de un asiento en estado publicado, el sistema mostrará un mensaje de error informando que la operación no está permitida.