### PR TITLE
[ADD] account_analytic_ux: automatic cost segmentation for projects

### DIFF
--- a/account_analytic_ux/README.md
+++ b/account_analytic_ux/README.md
@@ -1,0 +1,61 @@
+# Account Analytic UX
+
+This module enhances analytic accounting UX by adding automatic cost segmentation for projects, allowing service companies to compare analytic budgets against actual costs strictly classified by type.
+
+## Features
+
+- Automatic segmentation of analytic costs by type (labor hours vs. material movements)
+- Project-level activation field for segmented analytics
+- Auto-creation of analytic plans and accounts per project
+- Cost routing based on transaction nature, without manual intervention
+
+## Configuration
+
+1. Install the module
+2. Go to **Project > Configuration > Projects**
+3. Open or create a project
+4. In the **Settings** tab, enable **Segmented Cost Analytics**
+5. The system automatically creates the required analytic plans and accounts
+
+## Usage
+
+Once enabled on a project, costs are automatically routed:
+
+- **Labor costs** (timesheets with `employee_id` and product category `other`) → posted to the Hours plan
+- **Material costs** (inventory movements with category `picking_entry`) → posted to the Materials plan
+
+## Technical Details
+
+### Dependencies
+
+- `account`: Accounting
+- `analytic`: Analytic Accounting
+- `project`: Project Management
+- `hr_timesheet`: Timesheets
+
+### Models
+
+- `project.project`: Added `use_segmented_analytics` field and account auto-creation logic
+- `account.analytic.line`: Extended `create()` for automatic cost routing
+
+## Bug Tracker
+
+Bugs are tracked on [GitHub Issues](https://github.com/ingadhoc/account-financial-tools/issues). In case of trouble, please check there if your issue has already been reported.
+
+## Credits
+
+### Authors
+
+* ADHOC SA
+
+### Contributors
+
+* ADHOC SA <info@adhoc.com.ar>
+
+### Maintainers
+
+This module is maintained by ADHOC SA.
+
+## License
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/account_analytic_ux/__init__.py
+++ b/account_analytic_ux/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_analytic_ux/__manifest__.py
+++ b/account_analytic_ux/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "Account Analytic UX",
+    "version": "19.0.1.0.0",
+    "category": "Accounting",
+    "summary": "Automatic segmentation of project costs into Hours and Materials",
+    "author": "ADHOC SA",
+    "website": "https://www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "hr_timesheet",
+        "project_stock_account",
+    ],
+    "data": [
+        "views/project_project_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/account_analytic_ux/models/__init__.py
+++ b/account_analytic_ux/models/__init__.py
@@ -1,0 +1,3 @@
+from . import project_project
+from . import account_analytic_line
+from . import stock_move

--- a/account_analytic_ux/models/account_analytic_line.py
+++ b/account_analytic_ux/models/account_analytic_line.py
@@ -1,0 +1,79 @@
+from odoo import api, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = "account.analytic.line"
+
+    def _timesheet_preprocess_get_accounts(self, vals):
+        # picking_entry lines must not get any plan auto-fill: they already have
+        # the correct analytic_distribution from stock_move._get_analytic_distribution.
+        if vals.get("category") == "picking_entry":
+            return {}
+        # For segmented projects, route timesheet costs exclusively to the Hours plan.
+        # Calling super() would return ALL plan columns (hours + materials), which would
+        # inject the materials account on timesheet lines.
+        project_id = vals.get("project_id")
+        if project_id:
+            project = self.env["project.project"].browse(project_id)
+            if project.use_segmented_analytics:
+                hours_account = project._get_hours_analytic_account()
+                account_vals = {}
+                if project.account_id:
+                    account_vals["account_id"] = project.account_id.id
+                if hours_account:
+                    account_vals[hours_account.plan_id._column_name()] = hours_account.id
+                return account_vals
+        return super()._timesheet_preprocess_get_accounts(vals)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Force non-billable (empty so_line) for every line, timesheet or picking.
+        # For stock picking analytic lines also avoid hr_timesheet employee
+        # validation by not setting project_id: we only keep the account_id
+        # derived from the project. project_id is left set only on timesheets.
+        processed = list(vals_list)
+        deferred = {}
+        for idx, vals in enumerate(vals_list):
+            vals = dict(vals, so_line=False)
+            if vals.get("category") == "picking_entry" and vals.get("project_id"):
+                deferred[idx] = vals["project_id"]
+                vals = {k: v for k, v in vals.items() if k != "project_id"}
+            processed[idx] = vals
+
+        records = super().create(processed)
+
+        for idx, project_id in deferred.items():
+            project = self.env["project.project"].browse(project_id)
+            if not records[idx].account_id and project.account_id:
+                records[idx].sudo().write({"account_id": project.account_id.id})
+
+        return records
+
+    def _timesheet_postprocess_values(self, values):
+        # Segmented-analytics timesheets route costs to the Hours plan. For records
+        # that still have no account_id (legacy or edge cases), skip Odoo's
+        # "active account required" guard for those records and compute amount directly.
+        # picking_entry lines are excluded: their amount comes from the stock move.
+        if not any(f in values for f in ("unit_amount", "employee_id", "account_id")):
+            return super()._timesheet_postprocess_values(values)
+
+        segmented = self.filtered(
+            lambda t: not t.account_id and t.project_id.use_segmented_analytics and t.category != "picking_entry"
+        )
+        if not segmented:
+            return super()._timesheet_postprocess_values(values)
+
+        result = {}
+        non_segmented = self - segmented
+        if non_segmented:
+            result.update(super(AccountAnalyticLine, non_segmented)._timesheet_postprocess_values(values))
+
+        for timesheet in segmented.sudo():
+            cost = timesheet._hourly_cost()
+            amount = -timesheet.unit_amount * cost
+            amount_converted = timesheet.employee_id.currency_id._convert(
+                amount, timesheet.currency_id, self.env.company, timesheet.date
+            )
+            result[timesheet.id] = {"amount": amount_converted}
+
+        return result

--- a/account_analytic_ux/models/project_project.py
+++ b/account_analytic_ux/models/project_project.py
@@ -1,0 +1,87 @@
+from odoo import api, fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    HOURS_PLAN_NAME = "Plan de Horas"
+    MATERIALS_PLAN_NAME = "Plan de Materiales"
+
+    use_segmented_analytics = fields.Boolean(
+        string="Segmentación Automática de Costos (Horas/Materiales)",
+        help="Separa automáticamente los costos del proyecto en cuentas analíticas de Horas y Materiales. "
+        "Las partes de horas se imputan al Plan de Horas, los movimientos de inventario al Plan de Materiales.",
+    )
+
+    def _ensure_analytic_plan(self, plan_name):
+        plan = self.env["account.analytic.plan"].search([("name", "=", plan_name)], limit=1)
+        if not plan:
+            plan = self.env["account.analytic.plan"].create({"name": plan_name})
+        return plan
+
+    def _get_hours_analytic_account(self):
+        self.ensure_one()
+        plan = self.env["account.analytic.plan"].search([("name", "=", self.HOURS_PLAN_NAME)], limit=1)
+        return plan and self[plan._column_name()] or self.env["account.analytic.account"]
+
+    def _get_materials_analytic_account(self):
+        self.ensure_one()
+        plan = self.env["account.analytic.plan"].search([("name", "=", self.MATERIALS_PLAN_NAME)], limit=1)
+        return plan and self[plan._column_name()] or self.env["account.analytic.account"]
+
+    def _get_or_create_analytic_account(self, name, plan):
+        account = self.env["account.analytic.account"].search([("name", "=", name), ("plan_id", "=", plan.id)], limit=1)
+        if not account:
+            account = self.env["account.analytic.account"].create({"name": name, "plan_id": plan.id})
+        return account
+
+    def _setup_segmented_analytic_accounts(self):
+        hours_plan = self._ensure_analytic_plan(self.HOURS_PLAN_NAME)
+        materials_plan = self._ensure_analytic_plan(self.MATERIALS_PLAN_NAME)
+        hours_fname = hours_plan._column_name()
+        materials_fname = materials_plan._column_name()
+        for project in self:
+            if not project[hours_fname]:
+                project[hours_fname] = self._get_or_create_analytic_account(f"{project.name} - Horas", hours_plan)
+            if not project[materials_fname]:
+                project[materials_fname] = self._get_or_create_analytic_account(
+                    f"{project.name} - Materiales", materials_plan
+                )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        projects = super().create(vals_list)
+        projects.filtered("use_segmented_analytics")._setup_segmented_analytic_accounts()
+        return projects
+
+    def _get_segmented_plan_fnames(self):
+        """Return (hours_fname, materials_fname) for the segmented plans, or (None, None)."""
+        hours_plan = self.env["account.analytic.plan"].search([("name", "=", self.HOURS_PLAN_NAME)], limit=1)
+        materials_plan = self.env["account.analytic.plan"].search([("name", "=", self.MATERIALS_PLAN_NAME)], limit=1)
+        return (
+            hours_plan._column_name() if hours_plan else None,
+            materials_plan._column_name() if materials_plan else None,
+        )
+
+    @api.onchange("use_segmented_analytics")
+    def _onchange_use_segmented_analytics(self):
+        if not self.use_segmented_analytics:
+            hours_fname, materials_fname = self._get_segmented_plan_fnames()
+            if hours_fname:
+                self[hours_fname] = False
+            if materials_fname:
+                self[materials_fname] = False
+
+    def write(self, vals):
+        if "use_segmented_analytics" in vals and not vals["use_segmented_analytics"]:
+            # Force-clear plan columns in this same write so the form's current values
+            # don't restore them via super().write().
+            hours_fname, materials_fname = self._get_segmented_plan_fnames()
+            if hours_fname:
+                vals = dict(vals, **{hours_fname: False})
+            if materials_fname:
+                vals = dict(vals, **{materials_fname: False})
+        res = super().write(vals)
+        if vals.get("use_segmented_analytics"):
+            self.filtered("use_segmented_analytics")._setup_segmented_analytic_accounts()
+        return res

--- a/account_analytic_ux/models/stock_move.py
+++ b/account_analytic_ux/models/stock_move.py
@@ -1,0 +1,26 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_analytic_distribution(self):
+        distribution = super()._get_analytic_distribution()
+        project = self.picking_id.project_id
+        if not project.use_segmented_analytics:
+            return distribution
+        materials_account = project._get_materials_analytic_account()
+        if materials_account:
+            distribution = {str(materials_account.id): 100}
+        return distribution
+
+    def _prepare_analytic_line_values(self, account_field_values, amount, unit_amount):
+        res = super()._prepare_analytic_line_values(account_field_values, amount, unit_amount)
+        project = self.picking_id.project_id
+        # Do NOT set project_id: with a project_id, the profitability report treats the
+        # line as a timesheet ("Hours"). Leaving it empty (as standard project_stock_account
+        # does) keeps the picking_entry line in the "Materials" section. We only pin the
+        # project's main analytic account so it matches that section's domain.
+        if project.use_segmented_analytics and project.account_id:
+            res["account_id"] = project.account_id.id
+        return res

--- a/account_analytic_ux/views/project_project_views.xml
+++ b/account_analytic_ux/views/project_project_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_project_form_segmented_analytics" model="ir.ui.view">
+        <field name="name">project.project.form.segmented.analytics</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='analytic']" position="inside">
+                <field name="use_segmented_analytics"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- New module for segmenting project costs between hours and materials
- Configurable analytic plans with default hours and materials plans
- Automatic routing of analytic lines based on category

Change note: Ahora los proyectos pueden separar automáticamente los costos entre horas de trabajo y materiales. Al activar la segmentación en un proyecto, las horas cargadas se imputan en el plan de horas y los movimientos de stock en el plan de materiales, evitando duplicaciones en los análisis.