### PR TITLE
[DEL] account_ux: eliminar ocultamiento de hash en diarios de compra

### DIFF
--- a/account_ux/views/account_journal_views.xml
+++ b/account_ux/views/account_journal_views.xml
@@ -5,9 +5,6 @@
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
-            <field name="restrict_mode_hash_table" position="attributes">
-                <attribute name="invisible" separator=" or " add="type == 'purchase' and not restrict_mode_hash_table"/>
-            </field>
             <field name="country_code" position="before">
                 <field name="mail_template_id"  context="{'default_model': 'account.move'}"  invisible="type not in ['sale', 'purchase']"/>
             </field>
@@ -19,7 +16,6 @@
                         </p>
                     </div>
             </field>
-
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Odoo ya oculta este campo nativamente. Revierte 7af4fde4.