### PR TITLE
[FIX] account_ux: use partner as delivery when computing fiscal position

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -198,6 +198,20 @@ class AccountMove(models.Model):
         job_count = 1
         super()._cron_account_move_send(job_count=job_count)
 
+    def _compute_fiscal_position_id(self):
+        if self.env.user.has_group("account.group_delivery_invoice_address"):
+            return super()._compute_fiscal_position_id()
+        for move in self:
+            receipt_fp = {"in_receipt": move.company_id.account_purchase_receipt_fiscal_position_id}.get(move.move_type)
+            if receipt_fp:
+                move.fiscal_position_id = receipt_fp
+                continue
+            move.fiscal_position_id = (
+                self.env["account.fiscal.position"]
+                .with_company(move.company_id)
+                ._get_fiscal_position(move.partner_id, delivery=move.partner_id)
+            )
+
     @api.onchange("fiscal_position_id")
     def _onchange_fiscal_position_id(self):
         """

--- a/account_ux/tests/test_account_ux.py
+++ b/account_ux/tests/test_account_ux.py
@@ -1,5 +1,6 @@
 import odoo.tests.common as common
 from odoo import Command, fields
+from odoo.tests.common import TransactionCase
 
 
 class TestAccountUXChangeCurrency(common.TransactionCase):
@@ -129,3 +130,37 @@ class TestAccountUXChangeCurrency(common.TransactionCase):
             initial_rate,
             "La tasa de cambio debe ser diferente a la inicial",
         )
+
+
+class TestComputeFiscalPosition(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.delivery_group = cls.env.ref("account.group_delivery_invoice_address")
+        cls.env.user.groups_id -= cls.delivery_group
+
+        cls.fiscal_position = cls.env["account.fiscal.position"].create({"name": "Test FP"})
+        cls.receipt_fp = cls.env["account.fiscal.position"].create({"name": "Receipt FP"})
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "property_account_position_id": cls.fiscal_position.id,
+            }
+        )
+
+    def test_invoice_fiscal_position_from_partner(self):
+        """Without group_delivery_invoice_address, invoice FP is set from partner."""
+        invoice = self.env["account.move"].create({"move_type": "out_invoice", "partner_id": self.partner.id})
+        self.assertEqual(invoice.fiscal_position_id, self.fiscal_position)
+
+    def test_receipt_uses_company_fiscal_position(self):
+        """in_receipt move type uses company's account_purchase_receipt_fiscal_position_id."""
+        self.env.company.account_purchase_receipt_fiscal_position_id = self.receipt_fp
+        invoice = self.env["account.move"].create({"move_type": "in_receipt", "partner_id": self.partner.id})
+        self.assertEqual(invoice.fiscal_position_id, self.receipt_fp)
+
+    def test_receipt_without_company_fp_uses_partner(self):
+        """in_receipt without company receipt FP falls back to partner's fiscal position."""
+        self.env.company.account_purchase_receipt_fiscal_position_id = False
+        invoice = self.env["account.move"].create({"move_type": "in_receipt", "partner_id": self.partner.id})
+        self.assertEqual(invoice.fiscal_position_id, self.fiscal_position)

--- a/account_ux/tests/test_account_ux.py
+++ b/account_ux/tests/test_account_ux.py
@@ -137,8 +137,6 @@ class TestComputeFiscalPosition(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.delivery_group = cls.env.ref("account.group_delivery_invoice_address")
-        cls.env.user.groups_id -= cls.delivery_group
-
         cls.fiscal_position = cls.env["account.fiscal.position"].create({"name": "Test FP"})
         cls.receipt_fp = cls.env["account.fiscal.position"].create({"name": "Receipt FP"})
         cls.partner = cls.env["res.partner"].create(
@@ -147,6 +145,11 @@ class TestComputeFiscalPosition(TransactionCase):
                 "property_account_position_id": cls.fiscal_position.id,
             }
         )
+
+    def setUp(self):
+        super().setUp()
+        # Ensure user doesn't have the delivery group so our override is executed
+        self.env.user.write({"group_ids": [(3, self.delivery_group.id)]})
 
     def test_invoice_fiscal_position_from_partner(self):
         """Without group_delivery_invoice_address, invoice FP is set from partner."""


### PR DESCRIPTION
- Override `_compute_fiscal_position_id` in `AccountMove`
- Skip override when user has `account.group_delivery_invoice_address`
- For `in_receipt` moves, use company's purchase receipt fiscal position if set
- Pass `move.partner_id` as delivery to `_get_fiscal_position` otherwise

Change note: Se corrige el cálculo de la posición fiscal en facturas y recibos de compra. Cuando la opción de dirección de entrega separada no está activa, el sistema usa el mismo contacto del documento como dirección de entrega al determinar la posición fiscal. Los recibos de compra también respetan la posición fiscal configurada en la empresa, evitando posiciones fiscales incorrectas.