### PR TITLE
[FIX] account_ux: skip currency rate refresh on payment entries

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -25,7 +25,11 @@ class AccountMove(models.Model):
 
         # Refresh the currency rate if no invoice date is set and the currency is different from company currency
         for move in self:
-            if not move.invoice_date and move.currency_id != move.company_id.currency_id:
+            if (
+                not move.invoice_date
+                and move.currency_id != move.company_id.currency_id
+                and move.is_invoice(include_receipts=True)
+            ):
                 move.refresh_invoice_currency_rate()
 
         # Use action_post to ensure the mail is sent only when the move is posted


### PR DESCRIPTION
When posting a payment entry in foreign currency (e.g. USD) with retention lines in company currency (e.g. ARS), calling refresh_invoice_currency_rate() on those entries caused Odoo to detect the invoice_currency_rate change and trigger tax line recomputation via _sync_dynamic_lines_with_taxes_recomputation.

Since retention lines have a different currency_id in their grouping key, they don't match any entry in tax_lines_mapping and end up in tax_lines_to_delete, being removed and replaced with a rebalancing line by Odoo.

Restrict the refresh to actual invoices/bills only (is_invoice(include_receipts=True)), which is the only case where this refresh is meaningful.