### PR TITLE
[FIX] account_ux: handle list domain in open_invalid_statements_action

### DIFF
--- a/account_ux/models/account_journal.py
+++ b/account_ux/models/account_journal.py
@@ -119,5 +119,8 @@ class AccountJournal(models.Model):
     def open_invalid_statements_action(self):
         self.ensure_one()
         res = super().open_invalid_statements_action()
-        res["domain"] = str(safe_eval(res["domain"]) + [("journal_id", "=", self.id)])
+        domain = res["domain"]
+        if isinstance(domain, str):
+            domain = safe_eval(domain)
+        res["domain"] = domain + [("journal_id", "=", self.id)]
         return res


### PR DESCRIPTION
The domain returned by super() may already be a Python list instead of a string representation. Calling safe_eval() on a list raises a TypeError.

Added an isinstance check to only evaluate the domain if it is a string, keeping the existing behavior for string domains while supporting list domains.