### PR TITLE
[FIX] account_ux: post draft move before setting credit card payment to paid

### DIFF
--- a/account_ux/models/account_payment.py
+++ b/account_ux/models/account_payment.py
@@ -42,4 +42,15 @@ class AccountPayment(models.Model):
 
     def action_post(self):
         super().action_post()
-        self.filtered(lambda pay: pay.outstanding_account_id.account_type == "liability_credit_card").state = "paid"
+        cc_payments = self.filtered(
+            lambda pay: pay.outstanding_account_id.account_type == "liability_credit_card"
+        )
+        if cc_payments:
+            # Post any moves left in draft before setting state='paid'. Without this,
+            # write({'state': 'paid'}) triggers a second move.action_post() on incomplete
+            # move lines (left in draft by _synchronize_to_moves during action_post when
+            # withholding taxes are involved), leaving the move in draft.
+            cc_payments.move_id.filtered(lambda m: m.state == "draft").with_context(
+                skip_account_move_synchronization=True
+            ).action_post()
+            cc_payments.state = "paid"


### PR DESCRIPTION
## Problema

Al registrar pagos masivos a proveedor con retenciones usando un journal de tarjeta de crédito (`liability_credit_card`), el asiento contable del pago quedaba en estado `draft`, causando el error:

> **Operación no válida: Solo puede conciliar los asientos publicados**

Reproducción: Factura A (RI→RI, con retenciones) + journal Tarjeta de Crédito VISA.
No reproduce: Factura C (monotrib, sin retenciones) o journals de banco.

## Causa raíz

El asiento se crea al momento de `account.payment.create()` (cuando vienen `write_off_line_vals`). En `action_post()`, `l10n_ar_tax.action_post()` asigna números de secuencia a `l10n_ar_withholding_line_ids` **antes** de llamar `super()`. Como el pago ya tiene `move_id`, esa escritura dispara `_synchronize_to_moves({'l10n_ar_withholding_line_ids'})` sobre el move en `draft`, que reconstruye las líneas.

Luego, cuando `base.action_post()` intenta `move.action_post()` desde `write({'state': 'in_process'})`, una interacción con `_sync_dynamic_lines()` puede dejar el move en draft. `account_ux.action_post()` entonces llama `write({'state': 'paid'})`, que dispara un **segundo** intento de `move.action_post()` (vía `base account.payment.write()`). Ese segundo intento también falla, y `_reconcile_after_post()` encuentra el move en `draft`.

Solo afecta tarjeta de crédito porque `account_ux` es el único lugar que setea `state='paid'` para `liability_credit_card` (base Odoo solo lo hace para `asset_cash`).

## Solución

Publicar explícitamente los moves que hayan quedado en `draft` **antes** de setear `state='paid'`, usando `skip_account_move_synchronization=True` para evitar loops de sync. De esta forma, el `write({'state': 'paid'})` subsiguiente no encuentra ningún move en draft y no intenta el segundo `action_post()` problemático.

```python
def action_post(self):
    super().action_post()
    cc_payments = self.filtered(
        lambda pay: pay.outstanding_account_id.account_type == "liability_credit_card"
    )
    if cc_payments:
        cc_payments.move_id.filtered(lambda m: m.state == "draft").with_context(
            skip_account_move_synchronization=True
        ).action_post()
        cc_payments.state = "paid"
```

`skip_account_move_synchronization=True` no bypasea lógica de negocio: solo evita que `_synchronize_business_models()` intente sincronizar extractos bancarios (no aplica a pagos). `_check_balanced()` y todas las validaciones de `_post()` siguen corriendo normalmente.

## Ticket

Fixes #119788 — Gastrotex S.R.L.: No puedo emitir pagos de forma masiva