### PR TITLE
[FIX] account_ux: respect skip_account_move_synchronization in _synchronize_to_moves

### DIFF
--- a/account_ux/models/account_payment.py
+++ b/account_ux/models/account_payment.py
@@ -40,6 +40,11 @@ class AccountPayment(models.Model):
                     % (pay.company_id.name, dict(pay._fields["payment_type"].selection).get(pay.payment_type))
                 )
 
+    def _synchronize_to_moves(self, changed_fields):
+        if self.env.context.get("skip_account_move_synchronization"):
+            return
+        return super()._synchronize_to_moves(changed_fields)
+
     def action_post(self):
         super().action_post()
         self.filtered(lambda pay: pay.outstanding_account_id.account_type == "liability_credit_card").state = "paid"


### PR DESCRIPTION
## Problema

Al registrar pagos masivos a proveedor con retenciones y journal de tarjeta de crédito, `_reconcile_after_post()` fallaba con:

> **Solo puede conciliar los asientos publicados**

El asiento quedaba en `draft` porque `l10n_ar_tax.action_post()` disparaba `_synchronize_to_moves()` sobre el move en DRAFT antes de llamar `super()`, impidiendo que `move.action_post()` lo publicara correctamente.

## Causa raíz

`_synchronize_business_models()` (dirección move→payment) ya respeta `skip_account_move_synchronization` para evitar loops. `_synchronize_to_moves()` (dirección payment→move) no tenía el check simétrico, por lo que no había forma de suprimir el sync en contextos donde era prematuro.

## Solución (2 PRs)

**Este PR** agrega el check simétrico en `_synchronize_to_moves()`:

```python
def _synchronize_to_moves(self, changed_fields):
    if self.env.context.get("skip_account_move_synchronization"):
        return
    return super()._synchronize_to_moves(changed_fields)
```

**PR relacionado** en `ingadhoc/odoo-argentina`: `l10n_ar_tax.action_post()` usa `with_context(skip_account_move_synchronization=True)` al asignar números de secuencia a `l10n_ar_withholding_line_ids`, previniendo el sync prematuro sobre el move en DRAFT. Los nombres ya están seteados antes del `super()`, así que `_prepare_move_withholding_lines()` los toma correctamente al construir el asiento.

## Resultado

- `super().action_post()` puede publicar el move sin interferencia
- `account_ux.action_post()` setea `state='paid'` sin drama (el move ya está publicado)
- `_reconcile_after_post()` encuentra el move publicado → funciona

Ticket: #119788 — Gastrotex S.R.L.: No puedo emitir pagos de forma masiva