### PR TITLE
[FIX] account_ux: post draft moves before forcing state=paid for credit cards

### DIFF
--- a/account_ux/models/account_payment.py
+++ b/account_ux/models/account_payment.py
@@ -33,4 +33,16 @@ class AccountPayment(models.Model):
 
     def action_post(self):
         super().action_post()
-        self.filtered(lambda pay: pay.outstanding_account_id.account_type == "liability_credit_card").state = "paid"
+        credit_card_payments = self.filtered(
+            lambda pay: pay.outstanding_account_id.account_type == "liability_credit_card"
+        )
+        # Withholding sequence assignment in l10n_ar_tax.action_post() writes
+        # l10n_ar_withholding_line_ids before super(), which triggers
+        # _synchronize_to_moves() on the draft move and can leave it in draft
+        # again after the base action_post() runs.  Post those moves explicitly
+        # before forcing state='paid' so _reconcile_after_post() doesn't find
+        # unposted entries.
+        draft_moves = credit_card_payments.move_id.filtered(lambda m: m.state == "draft")
+        if draft_moves:
+            draft_moves.with_context(skip_account_move_synchronization=True).action_post()
+        credit_card_payments.state = "paid"


### PR DESCRIPTION
## Problem

When paying vendor bills in bulk via a credit card journal, if the payment has withholding lines, `l10n_ar_tax.action_post()` writes the withholding sequence names to `l10n_ar_withholding_line_ids` **before** calling `super()`. That write triggers `_synchronize_to_moves()` on the draft move, rebuilding its lines. The base `action_post()` can then leave the move in draft again. When `account_ux` writes `state = 'paid'` (for `liability_credit_card` accounts), it fires a second `action_post()` on a still-draft move, and `_reconcile_after_post()` raises "Solo puede conciliar los asientos publicados".

Does not reproduce with:
- Invoices without withholdings + credit card: no premature `l10n_ar_withholding_line_ids` write.
- Invoices with withholdings + bank journal: `account_ux` only forces `state = 'paid'` for `liability_credit_card` accounts.

## Solution (workaround)

Before forcing `state = 'paid'` on credit card payments, explicitly post any moves that remain in draft using `skip_account_move_synchronization=True` to avoid triggering another sync.

## Test plan

1. Create vendor bill (Factura A, RI→RI) with withholding taxes configured.
2. Register bulk payment using a Credit Card journal.
3. Confirm the payment posts and reconciles without error.
4. Verify Factura C (no withholdings) + credit card and Factura A + bank journal still work.

Closes https://www.adhoc.inc/odoo/helpdesk/all-tickets/119788