### PR TITLE
[FIX] account_ux: make _synchronize_to_moves respect skip_account_move_synchronization

### DIFF
--- a/account_ux/models/account_payment.py
+++ b/account_ux/models/account_payment.py
@@ -31,6 +31,11 @@ class AccountPayment(models.Model):
         if not self._context.get("force_delete") and any(m.state not in ("draft", "canceled") for m in self):
             raise UserError(_("You cannot delete this payment, you should set it back to draft first."))
 
+    def _synchronize_to_moves(self, changed_fields):
+        if self.env.context.get("skip_account_move_synchronization"):
+            return
+        return super()._synchronize_to_moves(changed_fields)
+
     def action_post(self):
         super().action_post()
         self.filtered(lambda pay: pay.outstanding_account_id.account_type == "liability_credit_card").state = "paid"


### PR DESCRIPTION
## Problem

`_synchronize_business_models()` (move→payment direction) already skips when `skip_account_move_synchronization` is in context. `_synchronize_to_moves()` (payment→move direction) had no such guard, creating an asymmetry.

This asymmetry causes a premature sync on the draft move when `l10n_ar_tax.action_post()` writes withholding sequence names before calling `super()`. The base `action_post()` can then leave the move in draft, and `account_ux`'s credit-card `state='paid'` write fires a second `action_post()` on it — causing `_reconcile_after_post()` to raise "Solo puede conciliar los asientos publicados".

## Solution

Override `_synchronize_to_moves()` to short-circuit when `skip_account_move_synchronization` is in context, making it symmetric with `_synchronize_business_models()`. Companion change in `ingadhoc/odoo-argentina` uses this flag when writing the withholding sequence names.

## Test plan

See companion PR in `ingadhoc/odoo-argentina` (branch `18.0-h-119788-cav-1`).

Closes https://www.adhoc.inc/odoo/helpdesk/all-tickets/119788