### PR TITLE
[FIX] account_ux: handle list domain in open_invalid_statements_action

### DIFF
--- a/account_ux/models/account_journal.py
+++ b/account_ux/models/account_journal.py
@@ -111,5 +111,10 @@ class AccountJournal(models.Model):
     def open_invalid_statements_action(self):
         self.ensure_one()
         res = super().open_invalid_statements_action()
-        res["domain"] = str(safe_eval(res["domain"]) + [("journal_id", "=", self.id)])
+        # El dominio puede venir como string (acción estándar via _for_xml_id) o
+        # como lista (acción del widget de conciliación que agrega account_accountant).
+        domain = res.get("domain") or []
+        if isinstance(domain, str):
+            domain = safe_eval(domain)
+        res["domain"] = domain + [("journal_id", "=", self.id)]
         return res


### PR DESCRIPTION
## Problem

Clicking the journal dashboard button **"Invalid statement(s)"** on a bank/credit journal raised:

```
AttributeError: 'list' object has no attribute 'strip'
```

inside `safe_eval` (`compile_codeobj`).

## Root cause

`account_ux` overrides `account.journal.open_invalid_statements_action` and does:

```python
res["domain"] = str(safe_eval(res["domain"]) + [("journal_id", "=", self.id)])
```

This assumes `res["domain"]` is always a **string**. That holds when the parent is the core `account` action (`_for_xml_id` returns a string domain), but the enterprise `account_accountant` override returns the bank reconciliation widget action via `_action_open_bank_reconciliation_widget(...)`, whose `domain` is already a **Python list**. `safe_eval` then fails trying `expr.strip()` on a list.

## Fix

Normalize the domain regardless of incoming type before appending the journal filter:

```python
domain = res.get("domain") or []
if isinstance(domain, str):
    domain = safe_eval(domain)
res["domain"] = domain + [("journal_id", "=", self.id)]
```

A list domain is valid for `ir.actions.act_window`, so the surrounding `str(...)` is no longer needed.

## Test plan

- On a bank/credit journal with invalid (non-empty) statements and `account_accountant` installed, click **"Invalid statement(s)"** in the dashboard → opens the reconciliation widget filtered by the journal, no traceback.
- On a journal whose action still returns a string domain → still works (string branch).