### PR TITLE
[FIX] account_ux: express leftover residual in secondary currency on reconcile_on_company_currency

### DIFF
--- a/account_ux/models/account_move_line.py
+++ b/account_ux/models/account_move_line.py
@@ -100,12 +100,25 @@ class AccountMoveLine(models.Model):
                 res["partial_values"]["credit_amount_currency"] = credit_values["aml"].currency_id.round(
                     res["partial_values"]["credit_amount_currency"] * rate
                 )
+                # El residual que devuelve super quedó expresado en moneda de la compañía (por el shadow de
+                # arriba). Lo reexpresamos en la moneda secundaria real a la cotización del comprobante, igual
+                # que hacemos con el partial. Si no, el residual queda con el valor en moneda de compañía pero
+                # asociado a un apunte cuya currency_id es la secundaria, y cualquier consumidor del residual
+                # (ej. el wizard de conciliación / ajuste) lo interpreta como moneda secundaria sin convertir.
+                if res.get("credit_values"):
+                    res["credit_values"]["amount_residual_currency"] = credit_values["aml"].currency_id.round(
+                        res["credit_values"]["amount_residual"] * rate
+                    )
             if "original_currency" in debit_values:
                 debit_values["currency"] = debit_values["original_currency"]
                 rate = get_accounting_rate(debit_values)
-                res["partial_values"]["debit_amount_currency"] = credit_values["aml"].currency_id.round(
+                res["partial_values"]["debit_amount_currency"] = debit_values["aml"].currency_id.round(
                     res["partial_values"]["debit_amount_currency"] * rate
                 )
+                if res.get("debit_values"):
+                    res["debit_values"]["amount_residual_currency"] = debit_values["aml"].currency_id.round(
+                        res["debit_values"]["amount_residual"] * rate
+                    )
         return res
 
     def _compute_amount_residual(self):

--- a/account_ux/tests/__init__.py
+++ b/account_ux/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_account_ux
+from . import test_reconcile_on_company_currency

--- a/account_ux/tests/test_reconcile_on_company_currency.py
+++ b/account_ux/tests/test_reconcile_on_company_currency.py
@@ -1,0 +1,107 @@
+# © ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReconcileOnCompanyCurrency(AccountTestInvoicingCommon):
+    """Regresión del bug del residual en moneda secundaria al conciliar con
+    ``reconcile_on_company_currency`` activo.
+
+    Escenario: una compañía con ``reconcile_on_company_currency`` concilia un
+    apunte en moneda de compañía contra uno en moneda secundaria, dejando una
+    diferencia de redondeo. El override de ``_prepare_reconciliation_single_partial``
+    concilia en moneda de compañía (shadow), y debe reexpresar el residual
+    sobrante en la moneda secundaria real a la cotización del comprobante.
+
+    Antes del fix el residual quedaba con el valor en moneda de compañía pero
+    asociado a un apunte cuya ``currency_id`` es la secundaria, lo que hacía que
+    el wizard de ajuste lo multiplicara por la cotización y propusiera un importe
+    inflado (ver caso real ND-A vs RE-X: 624,79 ARS -> 900.010 ARS).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.company_data["company"]
+        # reconcile_on_company_currency sólo se permite con país Argentina.
+        # Las compañías argentinas exigen redondeo global (constraint de
+        # saas_client_l10n_ar); lo seteamos junto con el país para no pegar
+        # contra un estado intermedio inválido.
+        cls.company.write(
+            {
+                "country_id": cls.env.ref("base.ar").id,
+                "tax_calculation_rounding_method": "round_globally",
+            }
+        )
+        cls.company.reconcile_on_company_currency = True
+        cls.company_currency = cls.company_data["currency"]
+        # 1 unidad de moneda de compañía = 1000 unidades de la moneda secundaria
+        cls.foreign_currency = cls.setup_other_currency("EUR", rates=[("2016-01-01", 1000.0)])
+        cls.receivable = cls.company_data["default_account_receivable"]
+        # El override exige que la cuenta no fuerce una moneda propia.
+        cls.receivable.currency_id = False
+        cls.date = fields.Date.from_string("2016-01-01")
+
+    def _receivable_line(self, balance, currency, amount_currency):
+        """Crea un asiento posteado con una línea sobre la cuenta a cobrar y la
+        contrapartida en una cuenta de ingresos, y devuelve la línea a cobrar."""
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "date": self.date,
+                "journal_id": self.company_data["default_journal_misc"].id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": self.receivable.id,
+                            "balance": balance,
+                            "currency_id": currency.id,
+                            "amount_currency": amount_currency,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.company_data["default_account_revenue"].id,
+                            "balance": -balance,
+                            "currency_id": currency.id,
+                            "amount_currency": -amount_currency,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        return move.line_ids.filtered(lambda line: line.account_id == self.receivable)
+
+    def test_residual_currency_expressed_in_secondary_currency(self):
+        # Débito en moneda de compañía (como la ND en ARS): 99,50.
+        debit_line = self._receivable_line(99.50, self.company_currency, 99.50)
+        # Crédito en moneda secundaria (como el recibo en USD): -100.000 EUR @ 1000 = -100 de compañía.
+        credit_line = self._receivable_line(-100.0, self.foreign_currency, -100000.0)
+
+        debit_values = {
+            "aml": debit_line,
+            "amount_residual": debit_line.amount_residual,
+            "amount_residual_currency": debit_line.amount_residual_currency,
+        }
+        credit_values = {
+            "aml": credit_line,
+            "amount_residual": credit_line.amount_residual,
+            "amount_residual_currency": credit_line.amount_residual_currency,
+        }
+
+        res = self.env["account.move.line"]._prepare_reconciliation_single_partial(debit_values, credit_values)
+
+        # El débito (99,50) se cancela por completo.
+        self.assertIsNone(res["debit_values"])
+        # Sobra residual en el crédito: 0,50 de moneda de compañía.
+        self.assertAlmostEqual(res["credit_values"]["amount_residual"], -0.50)
+        # El residual en moneda secundaria debe ser su equivalente a la cotización
+        # del comprobante (0,50 * 1000 = 500 EUR), NO el valor en moneda de compañía (0,50).
+        self.assertAlmostEqual(res["credit_values"]["amount_residual_currency"], -500.0)
+        # El partial cancela 99,50 de compañía = 99.500 EUR a la cotización del recibo.
+        self.assertAlmostEqual(res["partial_values"]["amount"], 99.50)
+        self.assertAlmostEqual(res["partial_values"]["credit_amount_currency"], 99500.0)


### PR DESCRIPTION
## Problema

Con `reconcile_on_company_currency` activo, al conciliar un apunte en moneda de compañía contra uno en moneda secundaria, el override de `_prepare_reconciliation_single_partial`:

1. "Sombrea" la moneda secundaria y llama a `super()` con `no_exchange_difference=True` para conciliar en moneda de compañía.
2. Reconvierte los `partial_values` (lo consumido) a la moneda secundaria real a la cotización del comprobante.

Pero **deja el residual sobrante** (`amount_residual_currency` en los `debit_values`/`credit_values` devueltos) expresado en moneda de compañía. Los consumidores de ese residual —en particular el wizard de conciliación/ajuste (`account.reconcile.wizard`)— interpretan esa magnitud en moneda de compañía como si fuera moneda secundaria y la multiplican por el tipo de cambio, proponiendo un ajuste (write-off) groseramente inflado.

Ejemplo: una diferencia de redondeo de 624,79 (moneda de compañía) aparece en el wizard como 624,79 de moneda secundaria y termina convertida a ~900.010 de moneda de compañía.

## Solución

Reexpresar el residual sobrante en la moneda secundaria a la misma cotización usada para el `partial`. De paso se corrige un bug latente que redondeaba el residual del débito con la moneda del apunte crédito en vez de la del débito (afecta el caso de dos apuntes con moneda secundaria).

## Test plan

- Nuevo test `account_ux/tests/test_reconcile_on_company_currency.py`: arma el escenario (compañía AR con `reconcile_on_company_currency`, apunte en moneda de compañía vs. apunte en moneda secundaria con diferencia de redondeo) y verifica que el residual devuelto queda en la moneda secundaria.
- Verificado que el test **falla** sin el fix (`-0.5 != -500.0`) y **pasa** con el fix.
- Suite completa de `account_ux` en verde (6 tests).