### PR TITLE
[ADD] account_ux: prevent suspense account equal to outstanding account

### DIFF
--- a/account_ux/models/__init__.py
+++ b/account_ux/models/__init__.py
@@ -12,5 +12,6 @@ from . import res_currency_rate
 from . import account_move
 from . import account_chart_template
 from . import account_payment
+from . import account_payment_method_line
 from . import account_reconcile_model
 from . import account_tax

--- a/account_ux/models/account_journal.py
+++ b/account_ux/models/account_journal.py
@@ -27,6 +27,39 @@ class AccountJournal(models.Model):
                 )
             )
 
+    @api.constrains(
+        "suspense_account_id",
+        "inbound_payment_method_line_ids",
+        "outbound_payment_method_line_ids",
+    )
+    def _check_suspense_account_not_outstanding(self):
+        """La cuenta transitoria (suspense) del diario no puede coincidir con una
+        cuenta de pagos/cobros pendientes (outstanding).
+
+        Si coinciden, el widget de conciliación bancaria nunca habilita "Validar":
+        ``bank.rec.widget._compute_state`` deja ``state='invalid'`` mientras la cuenta
+        transitoria siga presente en las líneas, y al conciliar contra un pago cuya
+        contrapartida está en esa misma cuenta, la transitoria nunca sale. El botón
+        queda gris sin mensaje que lo explique. Bloqueamos la configuración de raíz.
+        """
+        for journal in self:
+            suspense = journal.suspense_account_id
+            if not suspense:
+                continue
+            outstanding_accounts = (
+                journal.inbound_payment_method_line_ids | journal.outbound_payment_method_line_ids
+            ).payment_account_id
+            if suspense in outstanding_accounts:
+                raise ValidationError(
+                    _(
+                        "En el diario «%(journal)s» la cuenta transitoria (%(account)s) no puede ser la "
+                        "misma que una cuenta de pagos/cobros pendientes (outstanding). Si lo son, no vas a "
+                        "poder validar las conciliaciones bancarias contra esos pagos. Configurá cuentas distintas.",
+                        journal=journal.display_name,
+                        account=suspense.display_name,
+                    )
+                )
+
     def write(self, vals):
         """We need to allow to change to False the value for restricted for hash for the journal when this value is setted."""
         if "restrict_mode_hash_table" in vals and not vals.get("restrict_mode_hash_table"):

--- a/account_ux/models/account_payment_method_line.py
+++ b/account_ux/models/account_payment_method_line.py
@@ -1,0 +1,33 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class AccountPaymentMethodLine(models.Model):
+    _inherit = "account.payment.method.line"
+
+    @api.constrains("payment_account_id", "journal_id")
+    def _check_outstanding_account_not_suspense(self):
+        """La cuenta de pagos/cobros pendientes (outstanding) no puede coincidir con la
+        cuenta transitoria (suspense) del diario.
+
+        Es el mismo problema que ``account.journal._check_suspense_account_not_outstanding``,
+        pero disparado desde el otro lado: al editar la cuenta outstanding del método de
+        pago. Si coincide con la transitoria del diario, la conciliación bancaria nunca
+        se puede validar (el botón "Validar" queda gris).
+        """
+        for line in self:
+            suspense = line.journal_id.suspense_account_id
+            if line.payment_account_id and suspense and line.payment_account_id == suspense:
+                raise ValidationError(
+                    _(
+                        "La cuenta de pagos/cobros pendientes (%(account)s) no puede ser la misma que la "
+                        "cuenta transitoria del diario «%(journal)s». Si lo son, no vas a poder validar las "
+                        "conciliaciones bancarias.",
+                        account=line.payment_account_id.display_name,
+                        journal=line.journal_id.display_name,
+                    )
+                )


### PR DESCRIPTION
## What

Add validation constraints that prevent a bank journal's **suspense account** from being the same account as any of its **outstanding** (payment method) accounts.

## Why

When a journal's suspense account equals an outstanding receipts/payments account, a bank reconciliation can never be validated:

- `bank.rec.widget._compute_state` sets `state = 'invalid'` whenever the journal's suspense account is present among the widget lines.
- Reconciling a statement line against a payment whose counterpart lives in that same account leaves the suspense account in the lines.
- Result: the **Validate** button stays disabled regardless of amounts/rates, and with no message explaining why.

This is a configuration mistake, but Odoo allows it silently. The constraint blocks it at configuration time with a clear error, instead of leaving the user stuck on a greyed-out button.

## How

- `account.journal`: `suspense_account_id` cannot be any of the `payment_account_id` of its inbound/outbound payment method lines.
- `account.payment.method.line`: `payment_account_id` cannot equal the journal's `suspense_account_id`.

Two constraints so the misconfiguration is caught from both editing entry points.

## Test plan

- Configure a bank journal so its suspense account equals an outstanding account → `ValidationError`.
- Set an outstanding account equal to the journal's suspense account → `ValidationError`.
- Keep the accounts distinct → no error; bank reconciliation validates normally.