### PR TITLE
[FIX] account_ux: full width for narration on invoice form

### DIFF
--- a/account_ux/views/account_move_views.xml
+++ b/account_ux/views/account_move_views.xml
@@ -53,6 +53,9 @@
                 <button name="delete_number" string="Delete Number" invisible="state != 'cancel' or not name or name == '/'" type="object" help="Deleting the number will allow you to delete this invoice or to get a new number if you re-validate it. If this invoice represents a voided invoice, then you should not clean it." confirm="Warning! This can't be undone. Deleting the number will allow you to delete this invoice or to get a new number if you re-validate it. If this invoice represents a voided invoice, then you should not clean it. Do you want to continue?" groups="account.group_account_manager"/>
             </button>
 
+            <field name="narration" position="attributes">
+                <attribute name="colspan">2</attribute>
+            </field>
             <field name="narration" position="after">
                 <field name="internal_notes" colspan="2" nolabel="1" height="50" placeholder="Add an internal note..."/>
             </field>


### PR DESCRIPTION
Adding `internal_notes` as a sibling of `narration` inside the standard group (`col=2`) left `narration` with the default colspan of 1, so the Terms and Conditions box rendered at half width and wrapped text into many short lines. Upstream renders `narration` alone in that group, taking the full row.

Fix: set `colspan="2"` on `narration` so it takes the full row, matching `internal_notes` and the upstream layout.

Task: https://www.adhoc.inc/odoo/project.task/69685

**Test plan**
- Open a draft customer invoice form.
- The Terms and Conditions box below the invoice lines should span the full width of the left column (same width as the internal note box), instead of a narrow half-width box.