### PR TITLE
[FIX] account_ux: skip exchange diff on rounding residual with reconcile_on_company_currency

### DIFF
--- a/account_ux/models/account_move_line.py
+++ b/account_ux/models/account_move_line.py
@@ -121,6 +121,18 @@ class AccountMoveLine(models.Model):
                     )
         return res
 
+    def reconcile(self):
+        # Con reconcile_on_company_currency se concilia al TC del comprobante, así que el residuo remanente
+        # es puro redondeo y no debe generar diferencia de cambio. Propagamos no_exchange_difference a todo
+        # el reconcile porque el override del partial no alcanza la fase donde se crea el asiento.
+        if (
+            not self.env.context.get("no_exchange_difference")
+            and self.company_id.reconcile_on_company_currency
+            and not self.account_id.currency_id
+        ):
+            self = self.with_context(no_exchange_difference=True)
+        return super().reconcile()
+
     def _compute_amount_residual(self):
         """Cuando se realiza un cobro de un recibo y el comprobante que se paga tiene moneda secundaria y queda totalmente conciliado en moneda de compañía pero no en moneda secundaria (ejemplo: diferencia de un centavo) lo que hacemos con este método es forzar que quede conciliado también en moneda secundaria."""
         super()._compute_amount_residual()

--- a/account_ux/tests/test_reconcile_on_company_currency.py
+++ b/account_ux/tests/test_reconcile_on_company_currency.py
@@ -105,3 +105,22 @@ class TestReconcileOnCompanyCurrency(AccountTestInvoicingCommon):
         # El partial cancela 99,50 de compañía = 99.500 EUR a la cotización del recibo.
         self.assertAlmostEqual(res["partial_values"]["amount"], 99.50)
         self.assertAlmostEqual(res["partial_values"]["credit_amount_currency"], 99500.0)
+
+    def test_rounding_residual_does_not_create_exchange_move(self):
+        """Con ``reconcile_on_company_currency`` activo, conciliar dos apuntes en la misma moneda
+        secundaria que cierran exacto en secundaria pero difieren por redondeo en moneda de compañía
+        NO debe generar un asiento de diferencia de cambio (la promesa del setting)."""
+        exchange_journal = self.company.currency_exchange_journal_id
+        domain = [("journal_id", "=", exchange_journal.id)]
+        moves_before = self.env["account.move"].search_count(domain)
+        # Cierran exacto en moneda secundaria (100.000 EUR) pero difieren 0,01 en moneda de compañía.
+        debit_line = self._receivable_line(100.01, self.foreign_currency, 100000.0)
+        credit_line = self._receivable_line(-100.00, self.foreign_currency, -100000.0)
+
+        (debit_line + credit_line).reconcile()
+
+        self.assertEqual(
+            self.env["account.move"].search_count(domain),
+            moves_before,
+            "No debe crearse un asiento de diferencia de cambio por el residuo de redondeo.",
+        )


### PR DESCRIPTION
## Problem

With `reconcile_on_company_currency` enabled, reconciling a foreign-currency invoice against a receipt in the **same currency at the same rate** still generates a `0.01` exchange difference entry.

The invoice's company-currency balance is the sum of its per-line conversions (each rounded to 2 decimals), while the receipt converts the total in one step. Sum-of-rounded ≠ round-of-sum, so a 1-cent residual remains in company currency even though the foreign amount matches exactly. That cent is posted to the exchange difference account.

The setting is meant to *avoid all automatic exchange rate entries* by forcing the voucher rate. It already neutralizes the rate, so any leftover is a pure rounding residual — but the entry is still created.

## Cause

The override in `_prepare_reconciliation_single_partial` sets `no_exchange_difference=True`, but that context only covers the partial preparation. The exchange move is created later inside `reconcile()`, without the context — so the entry is generated anyway.

## Fix

Propagate `no_exchange_difference` at the `reconcile()` level when the company uses `reconcile_on_company_currency` and the account has no secondary currency (same condition as the existing partial override). The rounding residual is left on the line for manual reconciliation instead of hitting the exchange difference account.

## Test plan

- New regression test `test_rounding_residual_does_not_create_exchange_move` in `test_reconcile_on_company_currency.py`: two lines in the same secondary currency that match in secondary currency but differ by rounding in company currency are reconciled, and no exchange difference move is created.
- Existing `test_residual_currency_expressed_in_secondary_currency` still passes (unchanged behavior for the other direction).