### PR TITLE
[FIX] account_ux: respect move type when selecting mail template

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -67,7 +67,7 @@ class AccountMove(models.Model):
                 # Seteamos la data para que el cron nativo lo procese luego
                 rec.sending_data = {
                     "sending_methods": ["email"],
-                    "mail_template_id": rec.journal_id.mail_template_id.id,
+                    "mail_template_id": rec._get_mail_template().id,
                     "author_partner_id": self.env.user.partner_id.id,
                 }
                 continue
@@ -83,7 +83,7 @@ class AccountMove(models.Model):
 
     def _get_mail_template(self):
         res = super()._get_mail_template()
-        if self.journal_id.mail_template_id:
+        if self.journal_id.mail_template_id and not all(move.move_type in ("out_refund", "in_refund") for move in self):
             res = self.journal_id.mail_template_id
         return res
 


### PR DESCRIPTION
### Qué

`_get_mail_template` forzaba `journal.mail_template_id` para todos los `move_type`. En l10n_ar la nota de crédito comparte diario con la factura, así que las NC terminaban enviándose con la plantilla de la factura (cruce FA↔NC). Es una regresión respecto de 17.0, donde el flujo nativo elegía la plantilla por tipo de documento.

### Cambio

- `_get_mail_template`: solo pisa con la plantilla del diario en facturas; las notas de crédito (`out_refund` / `in_refund`) caen al `super()` → plantilla nativa de NC (`account.email_template_edi_credit_note`).
- `action_send_invoice_mail` (autoenvío asincrónico): resuelve la plantilla vía `_get_mail_template()` en lugar de hardcodear `journal.mail_template_id`, para que el autoenvío respete también el tipo de documento.

Restaura el comportamiento de 17.0 (factura y nota de crédito con plantillas distintas) sin agregar campos nuevos.

### Test plan

1. Configurar un diario de ventas con `mail_template_id`.
2. Postear una factura en ese diario → se envía con la plantilla del diario.
3. Postear una nota de crédito en el mismo diario → se envía con la plantilla nativa de NC, no la de la factura.