### PR TITLE
[FIX] account_journal_security: respect security on payment register

### DIFF
--- a/account_journal_security/__init__.py
+++ b/account_journal_security/__init__.py
@@ -2,4 +2,4 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from . import models
+from . import models, wizards

--- a/account_journal_security/wizards/__init__.py
+++ b/account_journal_security/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import account_payment_register

--- a/account_journal_security/wizards/account_payment_register.py
+++ b/account_journal_security/wizards/account_payment_register.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = "account.payment.register"
+
+    def _get_batch_available_journals(self, batch_result):
+        # `journal_id` es un campo stored con compute_sudo=True (default de Odoo para
+        # computed stored). Cuando el ORM lo precomputa eleva el recordset a sudo y este
+        # search de diarios corre en sudo, bypaseando las ir.rules de journal_security.
+        # Como resultado, diarios total-restringidos a otros usuarios se cuelan en
+        # available_journal_ids y disparan un AccessError al renderizarse el pago masivo.
+        # Apagamos el sudo (env.uid ya es el usuario real) para que las reglas apliquen,
+        # y activamos journal_security para filtrar tambien los diarios de solo lectura.
+        wizard = self.sudo(False).with_context(journal_security=True)
+        return super(AccountPaymentRegister, wizard)._get_batch_available_journals(batch_result)


### PR DESCRIPTION
## Problema
En el registro de pago **masivo**, al seleccionar un diario saltaba un `AccessError` mencionando un diario totalmente restringido a otros usuarios, incluso eligiendo un diario permitido. El pago individual no se veía afectado.

## Causa
`available_journal_ids` se computaba en sudo: `journal_id` es un campo computed **stored** con `compute_sudo=True`, así que cuando el ORM lo precomputa eleva el recordset y el search de diarios corre en sudo, **bypaseando las record rules** de journal security. Los diarios total-restringidos se colaban en `available_journal_ids` y disparaban el `AccessError` al renderizarse.

## Solución
Override de `_get_batch_available_journals` que corre el search como el **usuario real** (`sudo(False)`), para que las record rules vuelvan a aplicar. Se mantiene el contexto `journal_security` para el filtro de modificación.

## Test plan
- Configurar un diario bancario (con métodos de pago) totalmente restringido a ciertos usuarios.
- Como usuario **sin** acceso a ese diario, registrar pago masivo sobre facturas de más de un partner.
- **Antes:** `AccessError` al abrir/elegir diario.
- **Después:** el diario restringido no aparece y el pago masivo se crea con un diario permitido.