### PR TITLE
[FIX] account_ux: do not read company fields on a multi-company recordset

### DIFF
--- a/account_ux/models/account_move_line.py
+++ b/account_ux/models/account_move_line.py
@@ -125,10 +125,15 @@ class AccountMoveLine(models.Model):
         # Con reconcile_on_company_currency se concilia al TC del comprobante, así que el residuo remanente
         # es puro redondeo y no debe generar diferencia de cambio. Propagamos no_exchange_difference a todo
         # el reconcile porque el override del partial no alcanza la fase donde se crea el asiento.
+        # Los apuntes pueden ser de compañías distintas de un mismo grupo (ejemplo: transferencia interna
+        # entre sucursal y matriz, que odoo permite si comparten root_id), por eso no leemos los campos
+        # directo del recordset: sería un ensure_one() implícito.
+        companies = self.company_id
         if (
             not self.env.context.get("no_exchange_difference")
-            and self.company_id.reconcile_on_company_currency
-            and not self.account_id.currency_id
+            and companies
+            and all(companies.mapped("reconcile_on_company_currency"))
+            and not self.account_id.mapped("currency_id")
         ):
             self = self.with_context(no_exchange_difference=True)
         return super().reconcile()

--- a/account_ux/tests/test_reconcile_on_company_currency.py
+++ b/account_ux/tests/test_reconcile_on_company_currency.py
@@ -124,3 +124,81 @@ class TestReconcileOnCompanyCurrency(AccountTestInvoicingCommon):
             moves_before,
             "No debe crearse un asiento de diferencia de cambio por el residuo de redondeo.",
         )
+
+
+@tagged("post_install", "-at_install")
+class TestReconcileBranchCompanies(AccountTestInvoicingCommon):
+    """Conciliar apuntes de dos compañías del mismo grupo (sucursal <-> matriz).
+
+    El override de ``reconcile()`` leía ``self.company_id.reconcile_on_company_currency``
+    sobre el recordset, lo que es un ``ensure_one()`` implícito y rompía con
+    ``ValueError: Expected singleton`` cuando los apuntes son de dos compañías.
+
+    El flujo es válido: odoo valida ``len(self.company_id.root_id) > 1``, no
+    ``len(self.company_id)``, así que conciliar entre sucursales de una misma raíz está
+    permitido; y ``account_internal_transfer`` concilia a propósito la línea del pago
+    origen con la del pago par, que vive en la otra compañía del árbol.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.root_company = cls.company_data["company"]
+        cls.root_company.write({"child_ids": [Command.create({"name": "Branch account_ux"})]})
+        cls.cr.precommit.run()  # carga el plan de cuentas de la sucursal
+        cls.branch = cls.root_company.child_ids
+        cls.companies = cls.root_company + cls.branch
+        # reconcile_on_company_currency sólo se permite con país Argentina (constraint de
+        # saas_client_account), y las compañías argentinas exigen redondeo global (constraint
+        # de saas_client_l10n_ar); seteamos ambos junto al país para no pegar contra un estado
+        # intermedio inválido.
+        cls.companies.write(
+            {
+                "country_id": cls.env.ref("base.ar").id,
+                "tax_calculation_rounding_method": "round_globally",
+            }
+        )
+        cls.companies.reconcile_on_company_currency = True
+
+    def _cross_company_payment_term_lines(self):
+        """Factura en la sucursal y nota de crédito en la matriz, por el mismo importe.
+
+        Devuelve las dos líneas de término de pago, listas para conciliar entre sí.
+        """
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "invoice_date": "2016-01-01",
+                "company_id": self.branch.id,
+                "partner_id": self.partner_a.id,
+                "invoice_line_ids": [Command.create({"name": "product", "price_unit": 1000})],
+            }
+        )
+        invoice.action_post()
+        refund = self.env["account.move"].create(
+            {
+                "move_type": "out_refund",
+                "invoice_date": "2016-01-01",
+                "company_id": self.root_company.id,
+                "partner_id": self.partner_a.id,
+                "invoice_line_ids": [Command.create({"name": "product", "price_unit": 1000})],
+            }
+        )
+        refund.action_post()
+        return (invoice + refund).line_ids.filtered(lambda line: line.display_type == "payment_term")
+
+    def test_reconcile_branch_against_root(self):
+        lines = self._cross_company_payment_term_lines()
+
+        lines.reconcile()
+
+        self.assertEqual(lines.mapped("amount_residual"), [0, 0])
+
+    def test_reconcile_branch_against_root_setting_off_on_branch(self):
+        """El recordset multi-compañía tampoco debe romper si el setting no está uniforme."""
+        self.branch.reconcile_on_company_currency = False
+        lines = self._cross_company_payment_term_lines()
+
+        lines.reconcile()
+
+        self.assertEqual(lines.mapped("amount_residual"), [0, 0])


### PR DESCRIPTION
## Problem

`reconcile()` read `self.company_id.reconcile_on_company_currency` and `self.account_id.currency_id` straight off the recordset. Both are an implicit `ensure_one()`, so reconciling entries that belong to two companies of the same group raised:

```
ValueError: Expected singleton: res.company(18, 17)
```

Reported on ticket 123470 as a failure when transferring third-party checks between a branch and its root company, but the crash is generic: it happens while *reading* the field, regardless of the value of `reconcile_on_company_currency`. Any internal transfer between a branch and its root fails the same way (bank to bank, cash to bank), not only checks.

Introduced in #985 (f64fbba).

## Why the flow is valid

- Core allows it: `_check_amls_exigibility_for_reconciliation` validates `len(self.company_id.root_id) > 1`, not `len(self.company_id)`, so reconciling between branches of the same root is permitted.
- `account_internal_transfer` reconciles the source payment line against its paired payment line on purpose, and that pair lives in the other company of the tree (the `destination_journal_id` domain is `('company_id', 'child_of', ...)`).
- `l10n_latam_check_ux` computes the check's `company_id` from its last operation, precisely so a check can move across companies.

So the override cannot assume a single company.

## Fix

Read both fields through `mapped()` instead of off the recordset. `all()` keeps the current semantics for the single-company case and treats the setting as per-company. `self.account_id.currency_id` had the same latent defect — it breaks before core can raise its own clean `UserError` on mixed accounts — fixed along the way.

## Test plan

New `TestReconcileBranchCompanies` in `account_ux/tests/test_reconcile_on_company_currency.py`: an invoice on a branch reconciled against a credit note on the root company, with the setting enabled on both companies and with the setting mixed.

Without the fix:

```
ValueError: Expected singleton: res.company(18, 17)
0 failed, 2 error(s) of 2 tests
```

With the fix, running the whole module on an 18.0 database:

```
account_ux: 11 tests 7.64s 8145 queries
0 failed, 0 error(s) of 5 tests
```

The test deliberately does not go through internal transfers: `account_ux` does not depend on `account_internal_transfer`, so the regression has to live where the bug is and reproduce it with a plain `reconcile()`.

## 19.0

Not affected. `account_ux/models/account_move_line.py` on 19.0 has no `reconcile()` override — the propagation lives inside `_prepare_reconciliation_single_partial`, reading `debit_values["aml"].company_id`, which is a single line. No forward-port needed.
