### PR TITLE
[FIX] account_ux: remove obsolete payment method xpath in payment receipt

### DIFF
--- a/account_ux/views/report_payment_receipt_templates.xml
+++ b/account_ux/views/report_payment_receipt_templates.xml
@@ -7,8 +7,5 @@
         <xpath expr="//table[@name='invoices']" position="inside">
             <t t-if="not any(inv.currency_id != o.currency_id and inv.currency_id != o.company_id.currency_id for inv in invoices)" t-set="otherCurrency" t-value="False"/>
         </xpath>
-        <xpath expr="//div[@name='payment_method']//span[@t-field='o.payment_method_id.name']" position="attributes">
-            <attribute name="t-field">o.payment_method_line_id.name</attribute>
-        </xpath>
     </template>
 </data>


### PR DESCRIPTION
## Qué

Elimina el xpath de `account_ux/views/report_payment_receipt_templates.xml` que sobreescribía el método de pago en el recibo:

```xml
<xpath expr="//div[@name='payment_method']//span[@t-field='o.payment_method_id.name']" position="attributes">
    <attribute name="t-field">o.payment_method_line_id.name</attribute>
</xpath>
```

## Por qué

En el core de Odoo 19, la plantilla `account.report_payment_receipt_document` cambió y ese nodo (`//div[@name='payment_method']//span[@t-field='o.payment_method_id.name']`) ya no existe. Al cargar el módulo, el xpath no encuentra el elemento en la vista padre y rompe con `ParseError: Element ... cannot be located in parent view`.

El override venía arrastrado de un forward-port de 17.0 (#600) para mostrar el nombre de la línea de método de pago; el core actual ya cubre esa visualización, por lo que el override quedó obsoleto.

## Test plan

- Instalar/actualizar `account_ux` en 19.0 → ya no rompe el load de vistas.
- Imprimir un recibo de pago (`account.payment`) → el reporte se genera correctamente.