### PR TITLE
[IMP] account_debt_report: filter the debt detail by currency

### DIFF
--- a/account_debt_report/README.rst
+++ b/account_debt_report/README.rst
@@ -40,6 +40,53 @@ To use this module, you need to:
 #. Go to partners
 #. From one partner o sellecting multiple ones, choose "Print / Account Debt Report"
 
+Filtering by currency
+---------------------
+
+The "Company Currency" and "Secondary Currency" checks of the wizard select which items
+get into the report, and which amount columns are printed. Both come checked by default:
+
+* **Both checked (default)**: the consolidated report. Every item, the ones issued in a
+  foreign currency converted to the company currency along with their original amount,
+  exchange rate differences included.
+* **Company currency only**: only the items issued in the company currency. Items issued
+  in other currencies are left out entirely, not converted.
+* **Secondary currency only**: only the items issued in a currency other than the company
+  one, expressed in their own currency.
+
+This lets a customer that carries debt for the same partner in two currencies send a
+separate account statement per currency.
+
+Two consequences worth knowing:
+
+* **The individual views do not tie to the general ledger.** When a partner has items in
+  more than one currency, the company currency view leaves the foreign ones out, so its
+  balance will not match the general ledger of the receivable/payable account. The
+  consolidated report is the one that reconciles.
+* **Exchange rate differences follow the currency they were booked in.** They are born
+  reconciled, so they only ever show up with "Full history" checked. Odoo books the
+  difference on whichever side of the reconciliation is settled in the reconciliation
+  currency but still carries a residual in company currency, and that side depends on
+  both which document is foreign and the direction the rate moved. So a difference can
+  end up in the foreign currency, where the filter leaves it out of both individual
+  views, or in the company currency, where it does show — including for a document
+  issued in a foreign currency and collected in company currency, whose own document is
+  not in that view. Filtering by currency cannot avoid the second case.
+
+Each item is compared against the currency of its own company, so the filter stays exact
+when the report spans several companies with different currencies.
+
+**Companies reconciling on their own currency are left out of the filter**, and keep the
+behaviour they had before it existed: their items always come through and the checks only
+pick columns. Those companies book the exchange difference of a foreign document as a
+separate debit note in the company currency, so filtering would leave that note in without
+the document it adjusts and the balance would come out wrong. The setting lives in
+``account_ux``; without that module installed nothing is left out.
+
+When a partner carries debt in more than one foreign currency, the secondary currency
+columns add those amounts together, since the report has a single column pair for them.
+The amount is left without a currency label in that case.
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: http://runbot.adhoc.com.ar/

--- a/account_debt_report/i18n/account_debt_report.pot
+++ b/account_debt_report/i18n/account_debt_report.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-25 18:39+0000\n"
-"PO-Revision-Date: 2025-11-25 18:39+0000\n"
+"POT-Creation-Date: 2026-07-31 21:08+0000\n"
+"PO-Revision-Date: 2026-07-31 21:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -50,16 +50,6 @@ msgstr ""
 #. module: account_debt_report
 #: model:ir.model.fields,field_description:account_debt_report.field_account_debt_report_wizard__result_selection
 msgid "Account Type's"
-msgstr ""
-
-#. module: account_debt_report
-#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__company_currency
-msgid "Add columns for company currency?"
-msgstr ""
-
-#. module: account_debt_report
-#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__secondary_currency
-msgid "Add columns for secondary currency?"
 msgstr ""
 
 #. module: account_debt_report
@@ -169,6 +159,22 @@ msgstr ""
 #: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__company_id
 msgid ""
 "If you don't select a company, debt for all companies will be exported."
+msgstr ""
+
+#. module: account_debt_report
+#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__secondary_currency
+msgid ""
+"Includes only the items issued in a currency other than the company one, expressed in their own currency. Exchange rate differences booked in the company currency are left out, as they do not represent debt in this one.\n"
+"\n"
+"Checking both options gives the consolidated report: every item, the ones in foreign currency converted to the company currency along with their original amount, exchange rate differences included."
+msgstr ""
+
+#. module: account_debt_report
+#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__company_currency
+msgid ""
+"Includes the items issued in the company currency; the ones issued in other currencies are left out, not converted. Exchange rate differences follow the currency they were booked in, so a reconciliation between currencies can leave one here without the foreign item that generated it. For both reasons this report may not match the general ledger of the account.\n"
+"\n"
+"Checking both options gives the consolidated report: every item, the ones in foreign currency converted to the company currency along with their original amount, exchange rate differences included."
 msgstr ""
 
 #. module: account_debt_report

--- a/account_debt_report/i18n/es.po
+++ b/account_debt_report/i18n/es.po
@@ -79,16 +79,6 @@ msgid "Account Type's"
 msgstr "Tipos de Cuentas"
 
 #. module: account_debt_report
-#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__company_currency
-msgid "Add columns for company currency?"
-msgstr "¿Agregar columnas para la moneda de la empresa?"
-
-#. module: account_debt_report
-#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__secondary_currency
-msgid "Add columns for secondary currency?"
-msgstr "Agregar columnas para moneda secundaria?"
-
-#. module: account_debt_report
 #: model_terms:ir.ui.view,arch_db:account_debt_report.account_debt_report_wizard_form
 msgid "Cancel"
 msgstr "Cancelar"
@@ -200,6 +190,26 @@ msgid ""
 msgstr ""
 "Si no selecciona una compañía se mostará la deuda de todas las compañías "
 "disponibles."
+
+#. module: account_debt_report
+#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__secondary_currency
+msgid ""
+"Includes only the items issued in a currency other than the company one, expressed in their own currency. Exchange rate differences booked in the company currency are left out, as they do not represent debt in this one.\n"
+"\n"
+"Checking both options gives the consolidated report: every item, the ones in foreign currency converted to the company currency along with their original amount, exchange rate differences included."
+msgstr "Incluye únicamente los comprobantes emitidos en una moneda distinta a la de la compañía, expresados en su propia moneda. Las diferencias de cambio imputadas en la moneda de la compañía quedan afuera, porque no representan deuda en esta moneda.\n"
+"\n"
+"Marcando ambas opciones se obtiene el reporte consolidado: todos los comprobantes, los de moneda extranjera convertidos a moneda de la compañía junto con su importe en moneda original, incluyendo las diferencias de cambio."
+
+#. module: account_debt_report
+#: model:ir.model.fields,help:account_debt_report.field_account_debt_report_wizard__company_currency
+msgid ""
+"Includes the items issued in the company currency; the ones issued in other currencies are left out, not converted. Exchange rate differences follow the currency they were booked in, so a reconciliation between currencies can leave one here without the foreign item that generated it. For both reasons this report may not match the general ledger of the account.\n"
+"\n"
+"Checking both options gives the consolidated report: every item, the ones in foreign currency converted to the company currency along with their original amount, exchange rate differences included."
+msgstr "Incluye los comprobantes emitidos en la moneda de la compañía; los emitidos en otras monedas quedan afuera, no convertidos. Las diferencias de cambio siguen la moneda en la que fueron imputadas, así que una conciliación entre monedas puede dejar una acá sin el comprobante en divisa que la generó. Por estos dos motivos, este reporte puede no coincidir con el mayor contable de la cuenta.\n"
+"\n"
+"Marcando ambas opciones se obtiene el reporte consolidado: todos los comprobantes, los de moneda extranjera convertidos a moneda de la compañía junto con su importe en moneda original, incluyendo las diferencias de cambio."
 
 #. module: account_debt_report
 #: model:ir.model.fields,field_description:account_debt_report.field_account_debt_report_wizard__write_uid

--- a/account_debt_report/models/res_partner.py
+++ b/account_debt_report/models/res_partner.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from odoo import _, models
+from odoo.fields import Domain
 from odoo.tools.misc import formatLang
 
 # from odoo.exceptions import ValidationError
@@ -76,6 +77,62 @@ class ResPartner(models.Model):
             },
         }
 
+    def _get_debt_report_currency_mode(self):
+        """Currency mode requested for the report: "company", "secondary" or False.
+
+        The wizard lets the user tick the company currency, the secondary one or both.
+        Asking for both -or for none, which is what happens when the report is rendered
+        without these context keys- means the consolidated report, so we don't filter.
+        """
+        company_currency = bool(self.env.context.get("company_currency"))
+        secondary_currency = bool(self.env.context.get("secondary_currency"))
+        if company_currency == secondary_currency:
+            return False
+        return "company" if company_currency else "secondary"
+
+    def _get_debt_report_unfiltered_companies(self, companies):
+        """Companies whose items are never narrowed down by currency.
+
+        A company reconciling on its own currency books the exchange difference of a
+        foreign document as a separate debit note in the company currency. Filtering
+        would leave that note in without the document it adjusts, and the balance would
+        come out wrong, so those companies keep the behaviour they had before the filter
+        existed. The setting belongs to account_ux, which this module does not depend on,
+        hence checking that the field is there at all.
+        """
+        if "reconcile_on_company_currency" not in companies._fields:
+            return companies.browse()
+        return companies.filtered("reconcile_on_company_currency")
+
+    def _get_debt_report_currency_domain(self, currency_mode, companies):
+        """Domain restricting the items to the currency requested for the report.
+
+        An item is issued in the company currency when the currency it carries is the
+        currency of its own company, both of them stored on the line. Pairing them keeps
+        the filter exact even when the report spans companies with different currencies.
+        """
+        if not currency_mode:
+            return []
+        unfiltered = self._get_debt_report_unfiltered_companies(companies)
+        filtered = companies - unfiltered
+        if not filtered:
+            return []
+        in_company_currency = Domain.OR(
+            [
+                Domain("company_currency_id", "=", currency.id) & Domain("currency_id", "=", currency.id)
+                for currency in filtered.mapped("currency_id")
+            ]
+        )
+        if currency_mode == "company":
+            wanted = in_company_currency
+        else:
+            wanted = ~in_company_currency & Domain("amount_currency", "!=", 0.0)
+        # the filter only governs the companies it applies to
+        domain = wanted & Domain("company_id", "in", filtered.ids)
+        if unfiltered:
+            domain |= Domain("company_id", "in", unfiltered.ids)
+        return list(domain)
+
     def _get_debt_report_lines(self):
         # TODO ver si borramos este metodo que no tiene mucho sentido (get_line_vals)
         def get_line_vals(
@@ -115,24 +172,20 @@ class ResPartner(models.Model):
         historical_full = self.env.context.get("historical_full", False)
         company_id = self.env.context.get("company_id", False)
         show_invoice_detail = self.env.context.get("show_invoice_detail", False)
-        secondary_currency = self.env.context.get("secondary_currency")
-        only_currency_lines = not self.env.context.get("company_currency") and secondary_currency
+        currency_mode = self._get_debt_report_currency_mode()
         balance_in_currency = 0.0
         balance_currency = 0.0
         balance_in_currency_name = ""
         domain = []
 
         if company_id:
-            domain += [("company_id", "=", company_id)]
-            company_currency_ids = self.env["res.company"].browse(company_id).currency_id
+            companies = self.env["res.company"].browse(company_id)
         else:
-            domain += [("company_id", "in", self.env.companies.ids)]
-            company_currency_ids = self.env.companies.mapped("currency_id")
-        if only_currency_lines and len(company_currency_ids) == 1:
-            domain += [("currency_id", "not in", company_currency_ids.ids)]
+            companies = self.env.companies
+        company_currencies = companies.mapped("currency_id")
+        domain += [("company_id", "in", companies.ids)]
 
-        if only_currency_lines:
-            domain += [("amount_currency", "!=", 0.0)]
+        domain += self._get_debt_report_currency_domain(currency_mode, companies)
 
         if not historical_full:
             domain += [("reconciled", "=", False), ("full_reconcile_id", "=", False)]
@@ -161,20 +214,25 @@ class ResPartner(models.Model):
             balance = inicial_lines[0][1] if inicial_lines else 0.0
             balance_in_currency = 0.0
             balance_in_currency_name = ""
-            if len(company_currency_ids) == 1:
-                balance_in_currency, balance_in_currency_name = self._get_currency_balance(
-                    initial_domain, company_currency_ids
-                )
+            # asking only for the company currency leaves no secondary amount to show,
+            # and the domain of _get_currency_balance would contradict the one above
+            if currency_mode != "company":
+                balance_in_currency, balance_in_currency_name = self._get_currency_balance(initial_domain, companies)
+            # the running balance in currency has to start off the initial one too,
+            # otherwise its column ignores everything before from_date
+            balance_currency = balance_in_currency
 
             initial_line = get_line_vals(
                 name=_("INITIAL BALANCE"),
                 balance=balance,
                 amount_currency=balance_in_currency,
+                balance_currency=balance_in_currency,
             )
+            initial_line["currency_name"] = balance_in_currency_name
             res = [
                 self._format_debt_report_line(
                     initial_line,
-                    company_currency=company_currency_ids[0] if len(company_currency_ids) == 1 else False,
+                    company_currency=company_currencies[0] if len(company_currencies) == 1 else False,
                     secondary_currency=False,
                 )
             ]
@@ -255,12 +313,13 @@ class ResPartner(models.Model):
 
         return res
 
-    def _get_currency_balance(self, initial_domain, company_currency_ids):
+    def _get_currency_balance(self, initial_domain, companies):
         inicial_lines_currency = (
             self.env["account.move.line"]
             .sudo()
             ._read_group(
-                initial_domain + [("currency_id", "not in", company_currency_ids.ids)],
+                # same notion of "issued in a foreign currency" as the detail uses
+                initial_domain + self._get_debt_report_currency_domain("secondary", companies),
                 groupby=["partner_id"],
                 aggregates=["amount_currency:sum", "currency_id:array_agg"],
             )
@@ -274,13 +333,14 @@ class ResPartner(models.Model):
             first = inicial_lines_currency[0]
             if isinstance(first, dict):
                 balance_in_currency = first.get("amount_currency", 0.0)
-                balance_in_currency_name = (
-                    self.env["res.currency"].browse(first.get("currency_id")[0]).display_name
-                    if first.get("currency_id")
-                    else ""
-                )
-            elif isinstance(first, tuple):
+                currency_ids = first.get("currency_id") or []
+            else:
                 balance_in_currency = first[1]
-                balance_in_currency_name = self.env["res.currency"].browse(first[2][0]).display_name if first[2] else ""
+                currency_ids = first[2] or []
+            # only label the amount when every item shares one currency: the sum of
+            # several foreign currencies cannot be attributed to any single one
+            currencies = self.env["res.currency"].browse(set(currency_ids))
+            if len(currencies) == 1:
+                balance_in_currency_name = currencies.display_name
 
         return balance_in_currency, balance_in_currency_name

--- a/account_debt_report/tests/__init__.py
+++ b/account_debt_report/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_debt_report

--- a/account_debt_report/tests/test_account_debt_report.py
+++ b/account_debt_report/tests/test_account_debt_report.py
@@ -1,3 +1,6 @@
+from odoo import Command
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
@@ -31,16 +34,428 @@ class TestAccountDebtReport(TransactionCase):
         self.assertIn(self.env.company.currency_id.symbol, formatted_line["amount"])
         self.assertTrue(formatted_line["amount_currency"].startswith("USD "))
 
-    def test_debt_report_lines(self):
-        # Execute the method and validate output
-        report_lines = self.partner._get_debt_report_lines()
-        # Perform assertions to verify the behavior
-        self.assertIsInstance(report_lines, list, "Expected a list of report lines")
-        if report_lines:
-            first_line = report_lines[0]
-            self.assertIn("date", first_line, "Report line should contain 'date'")
-            self.assertIn("name", first_line, "Report line should contain 'name'")
-            self.assertIn("balance", first_line, "Report line should contain 'balance'")
+
+class DebtReportCommon(TransactionCase):
+    """A partner with its own receivable account, plus helpers to post debt entries."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # pin the report to a single company: how many currencies self.env.companies adds
+        # up to depends on the database, and it decides whether amounts are unambiguous
+        cls.company = cls.env.company
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+        cls.company_currency = cls.company.currency_id
+        cls.foreign_currency = cls.env.ref("base.EUR")
+        if cls.foreign_currency == cls.company_currency:
+            cls.foreign_currency = cls.env.ref("base.USD")
+        cls.foreign_currency.active = True
+        # drop whatever rates the database already carries for this currency, so the
+        # amounts below are deterministic whichever chart or demo data is installed
+        cls.env["res.currency.rate"].search(
+            [("currency_id", "=", cls.foreign_currency.id), ("company_id", "=", cls.company.id)]
+        ).unlink()
+        cls._set_foreign_rate("2024-01-01", 2.0)
+        cls.partner = cls.env["res.partner"].create({"name": "Debt Report Partner"})
+        # reuse the chart's accounts and misc journal: creating them needs required
+        # fields that other installed modules add, and those vary from build to build.
+        # The partner is brand new, so nothing else lands on its ledger anyway.
+        cls.receivable_account = cls.partner.with_company(cls.company).property_account_receivable_id
+        cls.counterpart_account = cls.env["account.account"].search(
+            [("account_type", "not in", ("asset_receivable", "liability_payable"))], limit=1
+        )
+        cls.journal = cls.env["account.journal"].search(
+            [("type", "=", "general"), ("company_id", "=", cls.company.id)], limit=1
+        )
+        assert (
+            cls.receivable_account and cls.counterpart_account and cls.journal
+        ), "the database needs a chart of accounts installed to run these tests"
+
+    @classmethod
+    def _set_foreign_rate(cls, date, rate):
+        return cls.env["res.currency.rate"].create(
+            {
+                "name": date,
+                "currency_id": cls.foreign_currency.id,
+                "company_id": cls.company.id,
+                "rate": rate,
+            }
+        )
+
+    @classmethod
+    def _create_debt_move(cls, balance, amount_currency=None, currency=None, date="2024-06-15"):
+        """Post an entry with a single receivable line for the test partner."""
+        currency = currency or cls.company_currency
+        if amount_currency is None:
+            amount_currency = balance
+        move = cls.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": cls.journal.id,
+                "date": date,
+                "currency_id": currency.id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "name": "debt",
+                            "account_id": cls.receivable_account.id,
+                            "partner_id": cls.partner.id,
+                            # on entries the currency lives on the line, the one on the
+                            # move only drives invoices (_compute_currency_id)
+                            "currency_id": currency.id,
+                            "balance": balance,
+                            "amount_currency": amount_currency,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "name": "debt counterpart",
+                            "account_id": cls.counterpart_account.id,
+                            "currency_id": currency.id,
+                            "balance": -balance,
+                            "amount_currency": -amount_currency,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        return move
+
+    @classmethod
+    def _receivable_line(cls, move):
+        return move.line_ids.filtered(lambda line: line.account_id == cls.receivable_account)
+
+    def _report_lines(self, historical_full=True, **context):
+        return self.partner.with_context(historical_full=historical_full, **context)._get_debt_report_lines()
+
+    def _report_move_names(self, **currency_flags):
+        """Names of the moves that made it into the report for the given flags."""
+        return [line["name"] for line in self._report_lines(**currency_flags)]
+
+
+class TestDebtReportCurrencyMode(DebtReportCommon):
+    """The currency checks of the wizard filter which items get into the report.
+
+    Ticking only one of them narrows the report down to the items issued in that
+    currency; ticking both (or neither, when the report is rendered without these
+    context keys) gives the consolidated report with every item.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # 100 in company currency, and 100 of the foreign currency (50 at rate 2.0)
+        cls.local_move = cls._create_debt_move(100.0)
+        cls.foreign_move = cls._create_debt_move(50.0, amount_currency=100.0, currency=cls.foreign_currency)
+
+    def test_currency_mode_matrix(self):
+        """Both ticked and none ticked mean the same thing: no filtering."""
+        cases = [
+            ({"company_currency": True, "secondary_currency": True}, False),
+            ({"company_currency": True, "secondary_currency": False}, "company"),
+            ({"company_currency": True}, "company"),
+            ({"company_currency": False, "secondary_currency": True}, "secondary"),
+            ({"secondary_currency": True}, "secondary"),
+            ({"company_currency": False, "secondary_currency": False}, False),
+            ({}, False),
+            # the context the distributor portal renders the report with
+            ({"secondary_currency": False}, False),
+        ]
+        for context, expected_mode in cases:
+            with self.subTest(context=context):
+                partner = self.partner.with_context(**context)
+                self.assertEqual(partner._get_debt_report_currency_mode(), expected_mode)
+
+    def test_both_currencies_include_all_lines(self):
+        names = self._report_move_names(company_currency=True, secondary_currency=True)
+        self.assertIn(self.local_move.name, names)
+        self.assertIn(self.foreign_move.name, names)
+
+    def test_only_secondary_currency_excludes_company_lines(self):
+        names = self._report_move_names(company_currency=False, secondary_currency=True)
+        self.assertEqual(names, [self.foreign_move.name])
+
+    def test_only_company_currency_excludes_foreign_lines(self):
+        names = self._report_move_names(company_currency=True, secondary_currency=False)
+        self.assertEqual(names, [self.local_move.name])
+
+    def test_currency_domain_pairs_each_company_with_its_own_currency(self):
+        """Every company is judged against its own currency, not against a shared list."""
+        company_only = self.partner._get_debt_report_currency_domain("company", self.company)
+        self.assertIn(("company_currency_id", "=", self.company_currency.id), company_only)
+        self.assertIn(("currency_id", "=", self.company_currency.id), company_only)
+        self.assertIn(("company_id", "in", self.company.ids), company_only)
+        secondary = self.partner._get_debt_report_currency_domain("secondary", self.company)
+        self.assertIn(("amount_currency", "!=", 0.0), secondary)
+        self.assertIn(("company_currency_id", "!=", self.company_currency.id), secondary)
+
+    def test_no_currency_mode_means_no_clause(self):
+        self.assertEqual(self.partner._get_debt_report_currency_domain(False, self.company), [])
+
+    def test_no_company_is_exempt_by_default(self):
+        """Nothing is exempt unless a company explicitly reconciles on its own currency."""
+        self.assertFalse(self.partner._get_debt_report_unfiltered_companies(self.company))
+
+    def test_foreign_line_without_amount_currency_only_shows_consolidated(self):
+        """This is the shape of an exchange rate difference on a foreign item.
+
+        It is born with the foreign currency but no amount in it, so it falls out of
+        both individual views and only shows up in the consolidated one.
+        """
+        exchange_like_move = self._create_debt_move(25.0, amount_currency=0.0, currency=self.foreign_currency)
+        receivable_line = self._receivable_line(exchange_like_move)
+        self.assertEqual(receivable_line.currency_id, self.foreign_currency)
+        self.assertEqual(receivable_line.amount_currency, 0.0)
+
+        self.assertNotIn(
+            exchange_like_move.name, self._report_move_names(company_currency=True, secondary_currency=False)
+        )
+        self.assertNotIn(
+            exchange_like_move.name, self._report_move_names(company_currency=False, secondary_currency=True)
+        )
+        self.assertIn(exchange_like_move.name, self._report_move_names(company_currency=True, secondary_currency=True))
+
+    def test_incomplete_currency_context_includes_all_lines(self):
+        """Rendering without both keys -the distributor portal- stays consolidated."""
+        for flags in [{}, {"secondary_currency": False}, {"company_currency": False}]:
+            with self.subTest(**flags):
+                names = self._report_move_names(**flags)
+                self.assertIn(self.local_move.name, names)
+                self.assertIn(self.foreign_move.name, names)
+
+
+@tagged("post_install", "-at_install")
+class TestDebtReportUnfilteredCompanies(DebtReportCommon):
+    """Companies reconciling on their own currency keep every item in the report.
+
+    Those book the exchange difference of a foreign document as a separate debit note in
+    the company currency, so filtering would leave the note in without the document it
+    adjusts and the balance would come out wrong.
+
+    Runs post_install because the setting belongs to account_ux, which this module does
+    not depend on and therefore loads after it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.local_move = cls._create_debt_move(100.0)
+        cls.foreign_move = cls._create_debt_move(50.0, amount_currency=100.0, currency=cls.foreign_currency)
+
+    def _reconcile_on_company_currency(self):
+        """Enable the setting, which account_ux only allows on Argentinian companies.
+
+        Those in turn require global rounding, so both go in the same write to avoid an
+        invalid intermediate state.
+        """
+        if "reconcile_on_company_currency" not in self.env["res.company"]._fields:
+            self.skipTest("reconcile_on_company_currency needs account_ux installed")
+        self.company.write(
+            {
+                "country_id": self.env.ref("base.ar").id,
+                "tax_calculation_rounding_method": "round_globally",
+            }
+        )
+        self.company.reconcile_on_company_currency = True
+
+    def test_reconciling_on_company_currency_skips_the_filter(self):
+        self._reconcile_on_company_currency()
+
+        self.assertEqual(self.partner._get_debt_report_unfiltered_companies(self.company), self.company)
+        self.assertEqual(self.partner._get_debt_report_currency_domain("company", self.company), [])
+        # end to end: every item comes through whichever check is ticked
+        for flags in [
+            {"company_currency": True, "secondary_currency": False},
+            {"company_currency": False, "secondary_currency": True},
+        ]:
+            with self.subTest(**flags):
+                names = self._report_move_names(**flags)
+                self.assertIn(self.local_move.name, names)
+                self.assertIn(self.foreign_move.name, names)
+
+    def test_the_filter_still_applies_without_the_setting(self):
+        if "reconcile_on_company_currency" not in self.env["res.company"]._fields:
+            self.skipTest("reconcile_on_company_currency needs account_ux installed")
+        self.company.reconcile_on_company_currency = False
+        names = self._report_move_names(company_currency=True, secondary_currency=False)
+        self.assertEqual(names, [self.local_move.name])
+
+
+class TestDebtReportInitialBalance(DebtReportCommon):
+    """With a from_date the initial balance uses the same currency filter as the detail."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # before the report window: 100 in company currency and 100 foreign (50 converted)
+        cls._create_debt_move(100.0, date="2024-01-10")
+        cls._create_debt_move(50.0, amount_currency=100.0, currency=cls.foreign_currency, date="2024-01-10")
+        # inside the report window, so the initial balance is not the only line
+        cls._create_debt_move(30.0, date="2024-06-15")
+        cls._create_debt_move(20.0, amount_currency=40.0, currency=cls.foreign_currency, date="2024-06-15")
+
+    def _initial_balance_line(self, **currency_flags):
+        return self._report_lines(from_date="2024-06-01", **currency_flags)[0]
+
+    def test_initial_balance_both_currencies(self):
+        line = self._initial_balance_line(company_currency=True, secondary_currency=True)
+        self.assertEqual(line["balance_raw"], 150.0)
+        self.assertEqual(line["amount_currency_raw"], 100.0)
+
+    def test_initial_balance_only_company_currency(self):
+        line = self._initial_balance_line(company_currency=True, secondary_currency=False)
+        self.assertEqual(line["balance_raw"], 100.0)
+        self.assertEqual(line["amount_currency_raw"], 0.0)
+
+    def test_initial_balance_only_secondary_currency(self):
+        line = self._initial_balance_line(company_currency=False, secondary_currency=True)
+        self.assertEqual(line["balance_raw"], 50.0)
+        self.assertEqual(line["amount_currency_raw"], 100.0)
+
+    def test_balance_in_currency_continues_from_the_initial_one(self):
+        """The currency balance column has to carry over what happened before from_date."""
+        lines = self._report_lines(from_date="2024-06-01", company_currency=True, secondary_currency=True)
+        self.assertEqual(lines[0]["balance_currency_raw"], 100.0)
+        foreign_rows = [line for line in lines if line["amount_currency_raw"] == 40.0]
+        self.assertEqual(len(foreign_rows), 1)
+        self.assertEqual(foreign_rows[0]["balance_currency_raw"], 140.0)
+
+    def test_initial_balance_in_currency_carries_its_label(self):
+        line = self._initial_balance_line(company_currency=True, secondary_currency=True)
+        self.assertTrue(line["amount_currency"].startswith(self.foreign_currency.display_name))
+
+    def test_initial_balance_mixing_currencies_carries_no_label(self):
+        """A sum of several foreign currencies cannot be attributed to any single one."""
+        third_currency = self.env.ref("base.GBP")
+        third_currency.active = True
+        self._create_debt_move(10.0, amount_currency=20.0, currency=third_currency, date="2024-01-10")
+        line = self._initial_balance_line(company_currency=True, secondary_currency=True)
+        self.assertEqual(line["amount_currency_raw"], 120.0)
+        self.assertFalse(line["amount_currency"].startswith(self.foreign_currency.display_name))
+
+
+class TestDebtReportExchangeDifference(DebtReportCommon):
+    """Where an exchange rate difference shows up follows from the currency it is in.
+
+    The core books the difference on whichever reconciled line is settled in the
+    reconciliation currency but still carries a residual in company currency, and the
+    difference inherits that line's currency. Which line that is depends on both which
+    side is foreign and the direction the rate moved, so a difference can end up in the
+    foreign currency -out of both individual views- or in the company currency -shown in
+    that view-. Both outcomes are pinned below. Either way they only surface with the
+    full history, since exchange differences are born reconciled.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # the foreign currency loses value between these two dates
+        cls._set_foreign_rate("2024-06-01", 4.0)
+        # ... and gains it between these other two, which flips which side of a
+        # reconciliation is left with a residual in company currency
+        cls._set_foreign_rate("2025-01-01", 4.0)
+        cls._set_foreign_rate("2025-06-01", 2.0)
+
+    def _exchange_difference_lines(self, first, second):
+        """Reconcile both moves and return their exchange difference receivable lines."""
+        lines = self._receivable_line(first) + self._receivable_line(second)
+        lines.reconcile()
+        return lines.exchange_move_ids.line_ids.filtered(lambda line: line.account_id == self.receivable_account)
+
+    def _settle_foreign_item_in_company_currency(self):
+        """Cross currency collection while the foreign currency loses value.
+
+        In this direction the core is left correcting the foreign side.
+        """
+        foreign_move = self._create_debt_move(
+            50.0, amount_currency=100.0, currency=self.foreign_currency, date="2024-01-10"
+        )
+        payment_move = self._create_debt_move(-60.0, date="2024-06-15")
+        return self._exchange_difference_lines(foreign_move, payment_move)
+
+    def test_difference_booked_in_the_foreign_currency_only_shows_consolidated(self):
+        """Booked on a foreign line, it carries no amount in that currency either.
+
+        So it falls out of both individual views and reconciles only on the consolidated
+        one.
+        """
+        exchange_lines = self._settle_foreign_item_in_company_currency()
+
+        self.assertTrue(exchange_lines)
+        self.assertEqual(exchange_lines.currency_id, self.foreign_currency)
+        self.assertEqual(exchange_lines.amount_currency, 0.0)
+
+        exchange_move_names = exchange_lines.move_id.mapped("name")
+        company_only = self._report_move_names(company_currency=True, secondary_currency=False)
+        secondary_only = self._report_move_names(company_currency=False, secondary_currency=True)
+        consolidated = self._report_move_names(company_currency=True, secondary_currency=True)
+        for name in exchange_move_names:
+            self.assertNotIn(name, company_only)
+            self.assertNotIn(name, secondary_only)
+            self.assertIn(name, consolidated)
+
+    def test_difference_booked_in_the_company_currency_shows_in_company_mode(self):
+        """Booked on a company currency line, filtering by currency cannot avoid it.
+
+        It shows in the company currency statement next to the item it corrects, while
+        the foreign counterpart of the reconciliation is not there.
+        """
+        local_move = self._create_debt_move(50.0, date="2024-01-10")
+        foreign_move = self._create_debt_move(
+            -25.0, amount_currency=-100.0, currency=self.foreign_currency, date="2024-06-15"
+        )
+        exchange_lines = self._exchange_difference_lines(local_move, foreign_move)
+
+        self.assertTrue(exchange_lines)
+        self.assertEqual(exchange_lines.currency_id, self.company_currency)
+
+        exchange_move_names = exchange_lines.move_id.mapped("name")
+        company_only = self._report_move_names(company_currency=True, secondary_currency=False)
+        secondary_only = self._report_move_names(company_currency=False, secondary_currency=True)
+        for name in exchange_move_names:
+            self.assertIn(name, company_only)
+            self.assertNotIn(name, secondary_only)
+
+    def test_cross_currency_collection_with_a_gaining_currency_shows_in_company_mode(self):
+        """The dominant case in Argentina, and the one the requirement was about.
+
+        A document issued in the foreign currency, collected in company currency, with
+        the foreign currency gaining value in between: the core is left correcting the
+        company currency side, so the difference lands in that statement even though the
+        document that generated it does not. Filtering by currency does not remove it.
+        """
+        foreign_move = self._create_debt_move(
+            25.0, amount_currency=100.0, currency=self.foreign_currency, date="2025-01-10"
+        )
+        payment_move = self._create_debt_move(-40.0, date="2025-06-15")
+        exchange_lines = self._exchange_difference_lines(foreign_move, payment_move)
+
+        self.assertTrue(exchange_lines)
+        self.assertEqual(exchange_lines.currency_id, self.company_currency)
+        self.assertIn(
+            exchange_lines.move_id.name,
+            self._report_move_names(company_currency=True, secondary_currency=False),
+        )
+        self.assertNotIn(
+            foreign_move.name,
+            self._report_move_names(company_currency=True, secondary_currency=False),
+        )
+
+    def test_exchange_differences_are_hidden_outside_the_full_history(self):
+        """Exchange differences are born reconciled, so pending balances never show them."""
+        exchange_lines = self._settle_foreign_item_in_company_currency()
+        self.assertTrue(exchange_lines)
+
+        for flags in [
+            {"company_currency": True, "secondary_currency": False},
+            {"company_currency": False, "secondary_currency": True},
+            {"company_currency": True, "secondary_currency": True},
+        ]:
+            with self.subTest(**flags):
+                names = self._report_move_names(historical_full=False, **flags)
+                for name in exchange_lines.move_id.mapped("name"):
+                    self.assertNotIn(name, names)
 
 
 class TestAccountDebtReportWizard(TransactionCase):
@@ -62,6 +477,26 @@ class TestAccountDebtReportWizard(TransactionCase):
         # Verificar que el método confirm se ejecuta correctamente
         action = self.wizard.with_context(active_ids=[self.partner.id]).confirm()
         self.assertTrue(action, "El método confirm debería retornar una acción de reporte")
+
+    def test_default_currencies_are_both(self):
+        """Printing without touching the wizard shows the whole debt, not only one currency."""
+        wizard = self.env["account.debt.report.wizard"].create({})
+        self.assertTrue(wizard.company_currency)
+        self.assertTrue(wizard.secondary_currency)
+
+    def test_confirm_passes_currency_flags_in_context(self):
+        """The report reads the flags from the context, so they have to travel there."""
+        action = self.wizard.with_context(
+            active_ids=[self.partner.id],
+            # otherwise report_action returns the report layout wizard instead
+            discard_logo_check=True,
+        ).confirm()
+        self.assertTrue(action["context"]["company_currency"])
+        self.assertTrue(action["context"]["secondary_currency"])
+
+    def test_at_least_one_currency_is_required(self):
+        with self.assertRaises(ValidationError):
+            self.wizard.write({"company_currency": False, "secondary_currency": False})
 
     def test_send_by_email_method_single_partner_uses_comment(self):
         action = self.wizard.with_context(active_id=self.partner.id).send_by_email()

--- a/account_debt_report/wizard/account_debt_report_wizard.py
+++ b/account_debt_report/wizard/account_debt_report_wizard.py
@@ -34,8 +34,26 @@ class AccountDebtReportWizard(models.TransientModel):
     historical_full = fields.Boolean(
         help="If true, then it will show all partner history. If not, only unreconciled items will be shown."
     )
-    company_currency = fields.Boolean(default=True, help="Add columns for company currency?")
-    secondary_currency = fields.Boolean(help="Add columns for secondary currency?")
+    company_currency = fields.Boolean(
+        default=True,
+        help="Includes the items issued in the company currency; the ones issued in other "
+        "currencies are left out, not converted. Exchange rate differences follow the "
+        "currency they were booked in, so a reconciliation between currencies can leave "
+        "one here without the foreign item that generated it. For both reasons this "
+        "report may not match the general ledger of the account.\n\n"
+        "Checking both options gives the consolidated report: every item, the ones in "
+        "foreign currency converted to the company currency along with their original "
+        "amount, exchange rate differences included.",
+    )
+    secondary_currency = fields.Boolean(
+        default=True,
+        help="Includes only the items issued in a currency other than the company one, "
+        "expressed in their own currency. Exchange rate differences booked in the company "
+        "currency are left out, as they do not represent debt in this one.\n\n"
+        "Checking both options gives the consolidated report: every item, the ones in "
+        "foreign currency converted to the company currency along with their original "
+        "amount, exchange rate differences included.",
+    )
 
     def confirm(self):
         active_ids = self.env.context.get("active_ids", False)


### PR DESCRIPTION
The "Company Currency" / "Secondary Currency" checks of the debt detail wizard used to
pick which **columns** to print, not which **items** to include — except for the
secondary-only case, which did filter. So printing in company currency brought every
item, the foreign ones converted, and a customer that collects per currency could not
get an account statement holding only the items issued in one currency.

Ticking a single check now narrows the report down to that currency. Ticking both keeps
the consolidated report, unchanged.

Task: https://www.adhoc.inc/mail/view?model=project.task&res_id=71211

## What changes

| Selection | Before | After |
|---|---|---|
| Company currency only | every item, foreign ones converted | only the items issued in the company currency |
| Secondary currency only | only the foreign items, in their own currency | unchanged |
| Both | consolidated, both column groups | unchanged |
| Wizard default | company currency only | **both** |

The default moves to both on purpose: with the checks now filtering, keeping the old
default would silently drop the foreign items from the statement of anybody printing
without touching the wizard, mass emailing included. With both ticked the total debt
keeps showing; the only visible change is that the output gains the secondary currency
columns.

Rendering the report without these context keys — the distributor portal does that —
keeps the consolidated behaviour, so that path is unaffected.

An item counts as issued in the company currency when the currency it carries is the
currency of its own company — both stored on the line — so the filter stays exact when
the report spans companies with different currencies, instead of being skipped.

**Companies reconciling on their own currency are left out of the filter** and keep the
behaviour they had before it existed: their items always come through and the checks only
pick columns. Those book the exchange difference of a foreign document as a separate debit
note in the company currency, so filtering would leave that note in without the document it
adjusts and the balance would come out wrong — reported while testing this branch. The
setting lives in `account_ux`, which this module does not depend on, so the field is
checked for presence rather than assumed, and its test runs `post_install`.

When a partner carries debt in more than one foreign currency the secondary columns add
those amounts together, since the report has a single column pair for them; the amount is
left without a currency label in that case.

## Exchange rate differences

No special handling, and **where a difference ends up does not follow from which
document is foreign**. Odoo books it on whichever side of the reconciliation is settled in
the reconciliation currency but still carries a residual in company currency, and that
side depends on the direction the rate moved as well. Both outcomes are pinned by tests:

- booked in the **foreign** currency (`amount_currency = 0`): the filter leaves it out of
  both single currency views, it only shows on the consolidated one;
- booked in the **company** currency: it shows on that statement even though the foreign
  document that generated it does not. Filtering by currency cannot avoid this.

Worth calling out for review: **a document issued in foreign currency and collected in
company currency lands in the second case whenever the foreign currency gained value in
between** — the ordinary direction in Argentina. So the company currency statement can
still carry an exchange difference without its originating document. Whether that is
acceptable or the differences should be excluded explicitly is a functional call, tracked
on the task.

Either way they only surface with "Full history" ticked, since they are born reconciled.

## Also fixed on the initial balance

Both surfaced while reviewing this change. They predate it, but they sit in the block it
touches and the new default puts them in front of everyone:

- the running balance in currency started at zero, so its column ignored everything
  before `from_date` while the company currency column did not — with 100 of a foreign
  currency before the window and 40 inside it, the column showed 40 instead of 140;
- the initial amount in currency was computed with its currency label and the label was
  thrown away, printing a bare number;
- it now uses the same notion of "issued in a foreign currency" as the detail, so the
  amount in currency is no longer dropped when several company currencies are involved.

## Consequence to know about

With items in more than one currency, the company currency view leaves the foreign ones
out, so its balance does not match the general ledger of the receivable/payable account.
The consolidated report is the one that reconciles. Documented in the README and in the
help of the checks.

## Test plan

`account_debt_report/tests/__init__.py` was missing, so the 6 tests the module already
had had never run. They pass now that they do.

29 tests, 0 failures:

```
odoo-bin -d <db> -u account_debt_report --test-enable --test-tags /account_debt_report
account_debt_report: 41 tests 6.28s 1824 queries
0 failed, 0 error(s) of 29 tests
```

Covered: the four flag combinations including the keys-absent one, the currency clause
pairing each company with its own currency, the companies left out of the filter, an item in foreign currency with no amount in
it (the shape of an exchange difference), the initial balance under `from_date` for each
combination plus its carry-over and its label, the two possible outcomes for an exchange
difference with real reconciliation, the new wizard default, and that the flags travel in
the context the report reads.

The tests pin the report to a single company and drop any pre-existing rate for the
currency they use, so they do not depend on how many companies, currencies or rates the
database happens to carry.

Verified by hand on the rendered `.ods` as well, with a partner holding 3 items in the
company currency and 2 in a foreign one: 5 rows consolidated, 3 with company currency
only, 2 with secondary only, and the column groups matching each selection.

