### PR TITLE
[ADD] account_invoice_historical_cost: freeze real cost on invoice lines

### DIFF
--- a/account_invoice_historical_cost/README.rst
+++ b/account_invoice_historical_cost/README.rst
@@ -1,0 +1,77 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============================
+Account Invoice Historical Cost
+===============================
+
+``account.invoice.report`` is a SQL view: its columns are recomputed on every
+query. ``price_margin`` and ``inventory_value`` are computed against the
+product's *current* cost (``standard_price``), so changing a product's cost
+today silently changes the margin of old, already posted invoices. This
+module freezes the real cost on the invoice line so historical margin
+analysis stays stable.
+
+What it does
+============
+
+#. Adds ``historical_cost`` and ``historical_cost_provisional`` on
+   ``account.move.line``. On posting a customer invoice (``out_invoice``,
+   ``out_refund``, ``out_receipt``), the real cost of the delivered goods
+   (COGS, FIFO/average/standard aware) is frozen on the line, using the same
+   formula the core uses to build the invoice's COGS journal items. Lines
+   without a valuated delivery yet are marked ``historical_cost_provisional``
+   and completed automatically once the related stock move is done.
+#. Overrides ``account.invoice.report`` so ``price_margin`` and
+   ``inventory_value`` read the frozen cost when present, falling back to the
+   current dynamic computation via ``COALESCE`` when it is not — so invoices
+   posted before installing this module keep showing exactly the same
+   numbers as before. Adds a derived measure ``historical_unit_cost``
+   (quantity-weighted) and a search filter on whether the cost is still
+   provisional.
+#. Both fields are exposed as optional (hidden by default) columns on
+   invoice lines / journal items lists, for auditing a specific line.
+
+Known limitations
+==================
+
+- **Opt-in module** (not ``auto_install``): each client decides when to
+  adopt this change of semantics. Without a backfill (deliberately not
+  implemented), the report will show a step in the numbers at the
+  installation date — old invoices keep the dynamic calculation, new ones
+  get the frozen cost.
+- Only sale documents are covered. ``inventory_value`` on vendor bills keeps
+  moving with the product's current cost, as before.
+- With periodic (non ``real_time``) valuation and partial invoicing, cost is
+  allocated by weighted average of the linked deliveries rather than
+  following FIFO consumption invoice by invoice. The total always
+  reconciles; a single invoice's allocation may not match its exact layer
+  consumption.
+- A valuation adjustment made after posting does not propagate to an
+  already posted invoice — same behavior as the core's COGS lines. To
+  reflect it, reset the invoice to draft and post it again.
+- In companies with ``real_time`` valuation, completing a provisional line
+  on delivery can leave the report diverging from the already posted COGS
+  journal item (which the core never corrects retroactively). This is a
+  known and accepted trade-off, not a bug.
+
+Operational note
+=================
+
+This module needs to be added by hand to runbot's "with tests" build module
+whitelist before its tests can run in CI.
+
+|company_logo|
+
+This module is maintained by |company|.
+
+|icon| |company|

--- a/account_invoice_historical_cost/__init__.py
+++ b/account_invoice_historical_cost/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import reports

--- a/account_invoice_historical_cost/__manifest__.py
+++ b/account_invoice_historical_cost/__manifest__.py
@@ -1,0 +1,43 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Account Invoice Historical Cost",
+    "version": "19.0.1.0.0",
+    "category": "Accounting",
+    "sequence": 14,
+    "summary": "Freeze the real cost (COGS) on the invoice line so historical "
+    "margin is not recomputed retroactively",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "images": [],
+    "depends": [
+        "stock_account",
+    ],
+    "data": [
+        "views/account_move_line_views.xml",
+        "views/account_move_views.xml",
+        "reports/account_invoice_report_views.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/account_invoice_historical_cost/models/__init__.py
+++ b/account_invoice_historical_cost/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_move_line
+from . import account_move
+from . import stock_move

--- a/account_invoice_historical_cost/models/account_move.py
+++ b/account_invoice_historical_cost/models/account_move.py
@@ -1,0 +1,42 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _post(self, soft=True):
+        # Must run before super(), which is where stock_account creates the
+        # COGS lines (_stock_account_prepare_realtime_out_lines_vals). This
+        # way _get_posted_cogs_value() never sees this invoice's own COGS
+        # lines, so the frozen value is bit-identical to the one the core
+        # uses to build them.
+        self._freeze_historical_cost()
+        return super()._post(soft)
+
+    def _freeze_historical_cost(self):
+        for move in self:
+            if not move.is_sale_document(include_receipts=True):
+                continue
+            # Deliberately NOT excluded for move_reverse_cancel (unlike
+            # stock_account._post): the cancellation credit note also needs
+            # its cost frozen, otherwise the net margin of invoice + reversal
+            # wouldn't be zero.
+            move = move.with_company(move.company_id)
+            anglo_saxon_price_ctx = move._get_anglo_saxon_price_ctx()
+            for line in move.invoice_line_ids:
+                if line.display_type != "product" or not line.product_id:
+                    continue
+                line._freeze_historical_cost(anglo_saxon_price_ctx)
+
+    def button_draft(self):
+        res = super().button_draft()
+        self.line_ids._clear_historical_cost()
+        return res
+
+    def button_cancel(self):
+        res = super().button_cancel()
+        self.line_ids._clear_historical_cost()
+        return res

--- a/account_invoice_historical_cost/models/account_move_line.py
+++ b/account_invoice_historical_cost/models/account_move_line.py
@@ -1,0 +1,82 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    # Nullable on purpose: NULL means "not frozen yet", the report falls back
+    # to the dynamic computation via COALESCE. No default, no compute.
+    historical_cost = fields.Monetary(
+        currency_field="company_currency_id",
+        store=True,
+        readonly=True,
+        copy=False,
+        groups="base.group_user",
+    )
+    historical_cost_provisional = fields.Boolean(
+        readonly=True,
+        copy=False,
+        groups="base.group_user",
+    )
+
+    def _freeze_historical_cost(self, anglo_saxon_price_ctx):
+        self.ensure_one()
+        # Signed as line.quantity, NOT flipped by move_type: that flip (core's
+        # `-1 if move_type == 'out_refund'`) is for the COGS journal amount,
+        # applied later by the report's _select(). _get_cogs_value() already
+        # returns an abs() unit price (stock_account), so quantity carries the
+        # only sign here — including the negative-quantity-line-inside-an-
+        # out_invoice edge case (AC17).
+        if self.product_id.is_storable:
+            valuation_moves = self._get_historical_cost_moves()
+            if valuation_moves:
+                # Reads stock.move.value directly: _get_cogs_value() nets a
+                # return's qty to zero and falls back to standard_price.
+                self._complete_historical_cost_from_moves(valuation_moves)
+            else:
+                cogs_qty = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
+                # Mirrors stock_account's own call (account_move.py,
+                # _stock_account_prepare_realtime_out_lines_vals): replaces the
+                # context on purpose, doesn't merge it.
+                price_unit = self.with_context(anglo_saxon_price_ctx)._get_cogs_value()  # pylint: disable=context-overridden
+                self.historical_cost = cogs_qty * price_unit
+                self.historical_cost_provisional = True
+        else:
+            self.historical_cost = self.quantity * self.product_id.standard_price
+            self.historical_cost_provisional = True
+
+    def _get_historical_cost_moves(self):
+        self.ensure_one()
+        moves = self._get_stock_moves().filtered(lambda m: m.state == "done")
+        if self.move_id.move_type == "out_refund":
+            return_moves = moves.filtered(lambda m: m.is_in and m.origin_returned_move_id)
+            return return_moves or moves.filtered(lambda m: not m.is_in)
+        return moves.filtered(lambda m: not m.is_in)
+
+    def _clear_historical_cost(self):
+        # Writing False through the ORM on a Monetary field stores 0.0, not
+        # SQL NULL — and 0.0 is a legitimate frozen value (a free sample),
+        # distinct from "not frozen" (§1 of the spec). Direct SQL is the only
+        # way to actually clear it back to NULL.
+        if not self:
+            return
+        self.env.cr.execute(
+            "UPDATE account_move_line SET historical_cost = NULL, historical_cost_provisional = NULL WHERE id IN %s",
+            [tuple(self.ids)],
+        )
+        self.invalidate_recordset(["historical_cost", "historical_cost_provisional"])
+
+    def _complete_historical_cost_from_moves(self, moves):
+        self.ensure_one()
+        total_qty = sum(
+            moves.mapped(lambda move: move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id))
+        )
+        if not total_qty:
+            return
+        unit_value = sum(moves.mapped("value")) / total_qty
+        cogs_qty = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
+        self.historical_cost = cogs_qty * unit_value
+        self.historical_cost_provisional = False

--- a/account_invoice_historical_cost/models/stock_move.py
+++ b/account_invoice_historical_cost/models/stock_move.py
@@ -1,0 +1,31 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _action_done(self, cancel_backorder=False):
+        moves = super()._action_done(cancel_backorder=cancel_backorder)
+        moves.filtered(lambda move: move.state == "done")._complete_provisional_historical_cost()
+        return moves
+
+    def _complete_provisional_historical_cost(self):
+        # Reads stock.move.value directly, never _get_cogs_value(): calling
+        # _get_cogs_value() here would make the line count itself, since
+        # sale_stock's _get_posted_cogs_value() sums COGS lines of the whole
+        # order without filtering state, and this invoice's own COGS line
+        # already exists by the time delivery happens.
+        candidate_lines = self.env["account.move.line"].search(
+            [
+                ("historical_cost_provisional", "=", True),
+                ("display_type", "=", "product"),
+                ("product_id", "in", self.product_id.ids),
+            ]
+        )
+        for line in candidate_lines:
+            related_moves = (line._get_stock_moves() & self).filtered(lambda move: move.state == "done")
+            if related_moves:
+                line._complete_historical_cost_from_moves(related_moves)

--- a/account_invoice_historical_cost/reports/__init__.py
+++ b/account_invoice_historical_cost/reports/__init__.py
@@ -1,0 +1,1 @@
+from . import invoice_report

--- a/account_invoice_historical_cost/reports/account_invoice_report_views.xml
+++ b/account_invoice_historical_cost/reports/account_invoice_report_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_invoice_report_search_historical_cost" model="ir.ui.view">
+        <field name="name">account.invoice.report.search.historical.cost</field>
+        <field name="model">account.invoice.report</field>
+        <field name="inherit_id" ref="account.view_account_invoice_report_search"/>
+        <field name="arch" type="xml">
+            <filter name="creditnote" position="after">
+                <separator/>
+                <filter string="Historical Cost is Provisional" name="historical_cost_provisional"
+                        domain="[('historical_cost_provisional', '=', True)]"/>
+                <filter string="Historical Cost is Real" name="historical_cost_real"
+                        domain="[('historical_cost_provisional', '=', False)]"/>
+            </filter>
+        </field>
+    </record>
+
+    <record id="view_account_invoice_report_pivot_historical_cost" model="ir.ui.view">
+        <field name="name">account.invoice.report.pivot.historical.cost</field>
+        <field name="model">account.invoice.report</field>
+        <field name="inherit_id" ref="account.view_account_invoice_report_pivot"/>
+        <field name="arch" type="xml">
+            <pivot position="inside">
+                <field name="historical_unit_cost" type="measure"/>
+            </pivot>
+        </field>
+    </record>
+
+</odoo>

--- a/account_invoice_historical_cost/reports/invoice_report.py
+++ b/account_invoice_historical_cost/reports/invoice_report.py
@@ -1,0 +1,68 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from odoo.tools import SQL
+
+SALE_MOVE_TYPES = ("out_invoice", "out_receipt", "out_refund")
+
+
+class AccountInvoiceReport(models.Model):
+    _inherit = "account.invoice.report"
+
+    historical_cost = fields.Float(readonly=True)
+    historical_cost_provisional = fields.Boolean(readonly=True)
+    historical_unit_cost = fields.Float(readonly=True, aggregator="avg")
+
+    _depends = {
+        "account.move.line": ["historical_cost", "historical_cost_provisional"],
+    }
+
+    def _select(self) -> SQL:
+        return SQL(
+            """
+            %s,
+            CASE WHEN move.move_type IN %s
+                 THEN line.historical_cost * account_currency_table.rate
+                      * (CASE WHEN move.move_type = 'out_refund' THEN 1 ELSE -1 END)
+            END AS historical_cost,
+            line.historical_cost_provisional AS historical_cost_provisional
+            """,
+            super()._select(),
+            SALE_MOVE_TYPES,
+        )
+
+    def _field_to_sql(self, alias: str, field_expr: str, query=None) -> SQL:
+        if field_expr == "inventory_value":
+            return SQL(
+                "COALESCE(%s, %s)",
+                self._field_to_sql(alias, "historical_cost", query),
+                super()._field_to_sql(alias, field_expr, query),
+            )
+        if field_expr == "price_margin":
+            # base_inventory_sql MUST come from super(), not self.: using
+            # self._field_to_sql(alias, "inventory_value", ...) here would
+            # coalesce it with historical_cost first, cancelling the delta
+            # to 0 always.
+            return SQL(
+                "%s + COALESCE(%s - %s, 0)",
+                super()._field_to_sql(alias, field_expr, query),
+                self._field_to_sql(alias, "historical_cost", query),
+                super()._field_to_sql(alias, "inventory_value", query),
+            )
+        if field_expr == "historical_unit_cost":
+            return SQL(
+                "-%s / NULLIF(%s, 0)",
+                self._field_to_sql(alias, "inventory_value", query),
+                self._field_to_sql(alias, "quantity", query),
+            )
+        return super()._field_to_sql(alias, field_expr, query)
+
+    def _read_group_select(self, aggregate_spec: str, query) -> SQL:
+        if aggregate_spec != "historical_unit_cost:avg":
+            return super()._read_group_select(aggregate_spec, query)
+        return SQL(
+            "COALESCE(-SUM(%(f_inv)s) / NULLIF(SUM(%(f_qty)s), 0.0), 0)",
+            f_qty=self._field_to_sql(self._table, "quantity", query),
+            f_inv=self._field_to_sql(self._table, "inventory_value", query),
+        )

--- a/account_invoice_historical_cost/tests/__init__.py
+++ b/account_invoice_historical_cost/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import test_historical_cost_post
+from . import test_historical_cost_delivery
+from . import test_historical_cost_report

--- a/account_invoice_historical_cost/tests/test_historical_cost_delivery.py
+++ b/account_invoice_historical_cost/tests/test_historical_cost_delivery.py
@@ -1,0 +1,271 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.stock_account.tests.common import TestStockValuationCommon
+from odoo.tests import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHistoricalCostDelivery(TestStockValuationCommon):
+    """Requires `sale`/`sale_stock` installed: they're what makes
+    `account.move.line._get_stock_moves()` resolve `sale_line_ids.move_ids`,
+    which is what our hook and the congelamiento formula rely on."""
+
+    def _confirm_sale_order(self, order):
+        # `ignore_exception` only exists if the optional OCA `sale_exception`
+        # module is installed (it isn't in every build); bypass its
+        # confirmation blocker only when the field is actually there.
+        if "ignore_exception" in order._fields:
+            order.ignore_exception = True
+        order.action_confirm()
+
+    def _confirm_and_deliver(self, product, quantity):
+        product.invoice_policy = "order"
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": quantity,
+                            "price_unit": 1000,
+                        },
+                    )
+                ],
+            }
+        )
+        self._confirm_sale_order(order)
+        picking = order.picking_ids
+        picking.move_ids.quantity = quantity
+        picking.move_ids.picked = True
+        picking.button_validate()
+        return order
+
+    def _invoice_order(self, order):
+        invoice = order._create_invoices()
+        invoice.action_post()
+        return invoice
+
+    def _product_line(self, invoice):
+        return invoice.line_ids.filtered(lambda l: l.display_type == "product")
+
+    def test_ac2_ac3_delivery_before_invoice(self):
+        product = self.product_fifo
+        self._make_in_move(product, 10, unit_cost=100)
+        self._make_in_move(product, 10, unit_cost=150)
+
+        order = self._confirm_and_deliver(product, 6)
+        invoice = self._invoice_order(order)
+        line = self._product_line(invoice)
+
+        self.assertFalse(line.historical_cost_provisional)
+        # Consumes the first FIFO layer (cost 100), not product.standard_price
+        # (which FIFO already recomputed against the remaining layer).
+        self.assertAlmostEqual(line.historical_cost, 6 * 100)
+
+    def test_ac4_complete_on_delivery(self):
+        product = self.product_standard
+        product.standard_price = 100.0
+        product.invoice_policy = "order"
+
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": 5,
+                            "price_unit": 1000,
+                        },
+                    )
+                ],
+            }
+        )
+        self._confirm_sale_order(order)
+
+        invoice = self._invoice_order(order)
+        line = self._product_line(invoice)
+        self.assertTrue(line.historical_cost_provisional)
+        self.assertAlmostEqual(line.historical_cost, 5 * 100.0)
+
+        product.standard_price = 200.0
+
+        picking = order.picking_ids
+        picking.move_ids.quantity = 5
+        picking.move_ids.picked = True
+        picking.button_validate()
+
+        self.assertFalse(line.historical_cost_provisional)
+        # Completed from the real stock.move.value — for a `standard`
+        # cost_method product, that value is computed against the cost
+        # in effect AT DELIVERY TIME (200), not the invoice-time estimate
+        # (100). Completing with the real value is the whole point of D1-c;
+        # here the real value happens to have moved too.
+        self.assertAlmostEqual(line.historical_cost, 5 * 200.0)
+
+    def test_ac3_divergence_after_delivery_real_time(self):
+        product = self.product_standard_auto  # real_time valuation
+        product.standard_price = 100.0
+        product.invoice_policy = "order"
+
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": 5,
+                            "price_unit": 1000,
+                        },
+                    )
+                ],
+            }
+        )
+        self._confirm_sale_order(order)
+
+        invoice = self._invoice_order(order)
+        line = self._product_line(invoice)
+        self.assertTrue(line.historical_cost_provisional)
+        self.assertAlmostEqual(line.historical_cost, 500.0)
+
+        # In real_time, the core already created a COGS line for this
+        # product/line pair when we posted (§2 of the spec applies
+        # regardless of delivery state for real_time valuation).
+        cogs_lines = invoice.line_ids.filtered(lambda l: l.display_type == "cogs" and l.cogs_origin_id == line)
+        self.assertTrue(cogs_lines)
+        cogs_amount_before = abs(cogs_lines[0].balance)
+        self.assertAlmostEqual(cogs_amount_before, 500.0)
+
+        product.standard_price = 200.0
+        picking = order.picking_ids
+        picking.move_ids.quantity = 5
+        picking.move_ids.picked = True
+        picking.button_validate()
+
+        self.assertFalse(line.historical_cost_provisional)
+        self.assertAlmostEqual(line.historical_cost, 1000.0)
+
+        # The journal's COGS line is never corrected retroactively (core
+        # behavior, §3) — the report now diverges from the already-posted
+        # entry. This divergence is the accepted trade-off of D1 (option c),
+        # documented in AC3, not a bug.
+        cogs_amount_after = abs(cogs_lines[0].balance)
+        self.assertAlmostEqual(cogs_amount_after, cogs_amount_before)
+        self.assertNotAlmostEqual(line.historical_cost, cogs_amount_after)
+
+    def test_ac16_immutable_after_later_valuation_adjustment(self):
+        product = self.product_fifo
+        in_move = self._make_in_move(product, 10, unit_cost=100)
+
+        order = self._confirm_and_deliver(product, 6)
+        invoice = self._invoice_order(order)
+        line = self._product_line(invoice)
+        historical_cost_before = line.historical_cost
+        self.assertTrue(historical_cost_before)
+
+        # Adjust the valuation of the original receipt after the fact
+        # (stock_account.stock.move.action_adjust_valuation flow): this must
+        # NOT propagate to the already-posted invoice (§7 / AC16). To reflect
+        # it, the invoice would need to go back to draft and be reposted.
+        in_move.value_manual = 200 * 10
+
+        self.assertEqual(line.historical_cost, historical_cost_before)
+
+    def test_ac4_no_double_counting_across_partial_invoices(self):
+        product = self.product_standard
+        product.standard_price = 100.0
+        product.invoice_policy = "order"
+
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_uom_qty": 8,
+                            "price_unit": 1000,
+                        },
+                    )
+                ],
+            }
+        )
+        self._confirm_sale_order(order)
+
+        invoice_1 = order._create_invoices(final=True)
+        invoice_1.invoice_line_ids.filtered(lambda l: l.display_type == "product").quantity = 4
+        invoice_1.action_post()
+        line_1 = self._product_line(invoice_1)
+        self.assertTrue(line_1.historical_cost_provisional)
+
+        picking = order.picking_ids
+        picking.move_ids.quantity = 8
+        picking.move_ids.picked = True
+        picking.button_validate()
+
+        self.assertFalse(line_1.historical_cost_provisional)
+        # 4 of the 8 delivered units belong to this invoice: not the full
+        # move value, and not inflated by the other 4 units' cost.
+        self.assertAlmostEqual(line_1.historical_cost, 4 * 100.0)
+
+    def test_return_credit_note_uses_return_move_value(self):
+        product = self.product_standard
+        product.standard_price = 50000.0
+        order = self._confirm_and_deliver(product, 1)
+        invoice = self._invoice_order(order)
+        line = self._product_line(invoice)
+        self.assertAlmostEqual(line.historical_cost, 50000.0)
+
+        product.standard_price = 70000.0
+
+        return_form = Form(
+            self.env["stock.return.picking"].with_context(
+                active_ids=order.picking_ids.ids,
+                active_id=order.picking_ids.id,
+                active_model="stock.picking",
+            )
+        )
+        return_picking = return_form.save()
+        return_picking.product_return_moves.quantity = 1.0
+        return_action = return_picking.action_create_returns()
+        return_pick = self.env["stock.picking"].browse(return_action["res_id"])
+        return_pick.move_ids.quantity = 1
+        return_pick.move_ids.picked = True
+        return_pick.button_validate()
+
+        credit_note = self.env["account.move"].create(
+            {
+                "move_type": "out_refund",
+                "partner_id": self.partner.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "quantity": 1,
+                            "price_unit": 1000,
+                            "sale_line_ids": [(6, 0, order.order_line.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+        credit_note.action_post()
+        credit_note_line = self._product_line(credit_note)
+
+        # The return move valued the goods at 50.000 (the cost at delivery
+        # time); the credit note must freeze that, not the 70.000 the ficha
+        # had when it was posted (report._select() flips the sign later).
+        self.assertAlmostEqual(credit_note_line.historical_cost, 50000.0)

--- a/account_invoice_historical_cost/tests/test_historical_cost_post.py
+++ b/account_invoice_historical_cost/tests/test_historical_cost_post.py
@@ -1,0 +1,261 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.addons.stock_account.tests.common import TestStockValuationCommon
+from odoo.tests import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHistoricalCostPost(TestStockValuationCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.service_product = cls.env["product.product"].create(
+            {
+                "name": "Service Product",
+                "type": "service",
+                "standard_price": 30.0,
+                "list_price": 100.0,
+            }
+        )
+
+    def _create_customer_invoice(self, product, quantity=1.0, price_unit=None, move_type="out_invoice", post=True):
+        move_form = Form(self.env["account.move"].with_context(default_move_type=move_type))
+        move_form.partner_id = self.partner
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.quantity = quantity
+            if price_unit is not None:
+                line_form.price_unit = price_unit
+            line_form.tax_ids.clear()
+        invoice = move_form.save()
+        if post:
+            invoice.action_post()
+        return invoice
+
+    def _product_line(self, invoice):
+        return invoice.line_ids.filtered(lambda l: l.display_type == "product")
+
+    def test_ac1_price_unaffected_by_cost_change(self):
+        product = self.product_standard
+        invoice = self._create_customer_invoice(product, quantity=6, price_unit=1000)
+        line = self._product_line(invoice)
+        historical_cost_before = line.historical_cost
+
+        report_before = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        margin_before = report_before.price_margin
+        inventory_value_before = report_before.inventory_value
+
+        product.standard_price = 150.0
+
+        report_after = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        self.assertEqual(line.historical_cost, historical_cost_before)
+        self.assertAlmostEqual(report_after.price_margin, margin_before)
+        self.assertAlmostEqual(report_after.inventory_value, inventory_value_before)
+
+    def test_ac5_service_product_provisional(self):
+        self.service_product.standard_price = 30.0
+        invoice = self._create_customer_invoice(self.service_product, quantity=2)
+        line = self._product_line(invoice)
+        self.assertTrue(line.historical_cost_provisional)
+        self.assertEqual(line.historical_cost, 60.0)
+
+        self.service_product.standard_price = 999.0
+        self.assertEqual(line.historical_cost, 60.0)
+
+    def test_ac5_storable_no_delivery_provisional(self):
+        product = self.product_fifo
+        invoice = self._create_customer_invoice(product, quantity=3, price_unit=1000)
+        line = self._product_line(invoice)
+        self.assertTrue(line.historical_cost_provisional)
+        self.assertEqual(line.historical_cost, 3 * product.standard_price)
+
+    def test_ac7_null_historical_cost_no_regression(self):
+        product = self.product_standard
+        invoice = self._create_customer_invoice(product, quantity=6, price_unit=1000)
+        line = self._product_line(invoice)
+        # Simulates an invoice posted before this module was installed:
+        # historical_cost is SQL NULL, not 0.0 (writing False through the ORM
+        # on a Monetary field stores 0.0, so this uses the same raw-SQL path
+        # as _clear_historical_cost).
+        line._clear_historical_cost()
+
+        report = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        expected_inventory_value = -6 * product.standard_price
+        self.assertAlmostEqual(report.inventory_value, expected_inventory_value)
+
+    def test_ac10_draft_clears_and_repost(self):
+        product = self.product_standard
+        invoice = self._create_customer_invoice(product, quantity=6, price_unit=1000)
+        line = self._product_line(invoice)
+        self.assertTrue(line.historical_cost)
+
+        invoice.button_draft()
+        self.assertFalse(line.historical_cost)
+        self.assertFalse(line.historical_cost_provisional)
+
+        line.quantity = 10
+        invoice.action_post()
+        self.assertEqual(line.historical_cost, 10 * product.standard_price)
+
+    def test_ac15_purchase_untouched(self):
+        product = self.product_standard
+        move_form = Form(self.env["account.move"].with_context(default_move_type="in_invoice"))
+        move_form.partner_id = self.vendor
+        move_form.invoice_date = fields.Date.today()
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.quantity = 4
+            line_form.price_unit = 100
+            line_form.tax_ids.clear()
+        bill = move_form.save()
+        bill.action_post()
+        line = self._product_line(bill)
+        self.assertFalse(line.historical_cost)
+
+        report = self.env["account.invoice.report"].search([("move_id", "=", bill.id)])
+        self.assertAlmostEqual(report.inventory_value, 4 * product.standard_price)
+
+    def test_ac17_negative_quantity_line_sign(self):
+        product = self.product_standard
+        move_form = Form(self.env["account.move"].with_context(default_move_type="out_invoice"))
+        move_form.partner_id = self.partner
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.quantity = 5
+            line_form.price_unit = 1000
+            line_form.tax_ids.clear()
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.quantity = -2
+            line_form.price_unit = 1000
+            line_form.tax_ids.clear()
+        invoice = move_form.save()
+        invoice.action_post()
+
+        negative_line = invoice.line_ids.filtered(lambda l: l.display_type == "product" and l.quantity == -2)
+        # historical_cost follows line.quantity's own sign (§1 of the spec),
+        # so a negative-quantity line inside an out_invoice comes out negative.
+        self.assertEqual(negative_line.historical_cost, -2 * product.standard_price)
+
+    def test_ac6_multi_company_with_company(self):
+        product = self.product_standard
+        product.with_company(self.company).standard_price = 100.0
+        product.with_company(self.other_company).standard_price = 500.0
+
+        invoice = (
+            self.env["account.move"]
+            .with_company(self.other_company)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "partner_id": self.partner.id,
+                    "company_id": self.other_company.id,
+                    "invoice_line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "product_id": product.id,
+                                "quantity": 3,
+                                "price_unit": 1000,
+                                "tax_ids": [],
+                            },
+                        )
+                    ],
+                }
+            )
+        )
+        # Active company stays self.company (the env we're running under);
+        # _post() must still resolve each move's OWN company, not the active
+        # one, when posting a batch that mixes companies.
+        invoice.action_post()
+
+        line = self._product_line(invoice)
+        self.assertAlmostEqual(line.historical_cost, 3 * 500.0)
+
+    def test_ac8_uom_conversion(self):
+        product = self.product_standard
+        product.standard_price = 100.0
+        move_form = Form(self.env["account.move"].with_context(default_move_type="out_invoice"))
+        move_form.partner_id = self.partner
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.product_uom_id = self.uom_pack_of_6
+            line_form.quantity = 2
+            line_form.price_unit = 1000
+            line_form.tax_ids.clear()
+        invoice = move_form.save()
+        invoice.action_post()
+
+        line = self._product_line(invoice)
+        # 2 packs of 6 = 12 units, at 100/unit.
+        self.assertAlmostEqual(line.historical_cost, 12 * 100.0)
+
+    def test_ac9_credit_note_is_opposite_of_invoice(self):
+        product = self.product_standard
+        invoice = self._create_customer_invoice(product, quantity=6, price_unit=1000)
+        line = self._product_line(invoice)
+
+        credit_note = self._refund(invoice)
+        credit_line = self._product_line(credit_note)
+
+        # historical_cost is signed as line.quantity (§1), and quantity on a
+        # credit note line is the same positive magnitude as on the invoice
+        # — the move_type sign flip lives only in the report's _select(), not
+        # on the line-level field. So both lines carry the same value here;
+        # what has to be opposite is the REPORT's price_margin, checked below.
+        self.assertAlmostEqual(credit_line.historical_cost, line.historical_cost)
+
+        report_invoice = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        report_credit_note = self.env["account.invoice.report"].search([("move_id", "=", credit_note.id)])
+        self.assertAlmostEqual(report_invoice.price_margin, -report_credit_note.price_margin)
+
+    def test_ac11_query_count_bounded(self):
+        # Not a tight equality: assertQueryCount only fails if the actual
+        # count goes OVER the ceiling, so this is a regression guard against
+        # an N+1 introduced later, not a brittle exact-count pin. Baseline
+        # measured on this suite; bump it (with a comment why) if a
+        # legitimate change moves it.
+        product = self.product_standard_auto  # real_time: no extra query vs core
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "quantity": 3,
+                            "price_unit": 1000,
+                            "tax_ids": [(5, 0, 0)],
+                        },
+                    )
+                ],
+            }
+        )
+        with self.assertQueryCount(default=140):  # baseline measured: 115
+            invoice.action_post()
+
+    def test_move_reverse_cancel_not_excluded(self):
+        # Unlike stock_account._post, our override does NOT early-return under
+        # move_reverse_cancel (§2 of the spec) — a cancellation credit note
+        # still needs its cost frozen, otherwise invoice + reversal wouldn't
+        # net to zero margin.
+        product = self.product_standard
+        move_form = Form(self.env["account.move"].with_context(default_move_type="out_refund"))
+        move_form.partner_id = self.partner
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.quantity = 6
+            line_form.price_unit = 1000
+            line_form.tax_ids.clear()
+        credit_note = move_form.save()
+        credit_note.with_context(move_reverse_cancel=True)._post(soft=False)
+
+        line = self._product_line(credit_note)
+        self.assertTrue(line.historical_cost)
+        self.assertEqual(line.historical_cost, line.quantity * product.standard_price)

--- a/account_invoice_historical_cost/tests/test_historical_cost_report.py
+++ b/account_invoice_historical_cost/tests/test_historical_cost_report.py
@@ -1,0 +1,87 @@
+# © 2026 ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.stock_account.tests.common import TestStockValuationCommon
+from odoo.tests import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHistoricalCostReport(TestStockValuationCommon):
+    def _create_customer_invoice(self, product, quantity, price_unit=1000):
+        move_form = Form(self.env["account.move"].with_context(default_move_type="out_invoice"))
+        move_form.partner_id = self.partner
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.quantity = quantity
+            line_form.price_unit = price_unit
+            line_form.tax_ids.clear()
+        invoice = move_form.save()
+        invoice.action_post()
+        return invoice
+
+    def test_ac12b_read_and_search(self):
+        product = self.product_standard
+        invoice = self._create_customer_invoice(product, quantity=6)
+
+        report = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        self.assertTrue(report.read(["historical_cost", "inventory_value", "price_margin"]))
+
+        found_provisional = self.env["account.invoice.report"].search(
+            [
+                ("move_id", "=", invoice.id),
+                ("historical_cost_provisional", "=", True),
+            ]
+        )
+        self.assertEqual(found_provisional, report)
+
+        ordered = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)], order="price_margin desc")
+        self.assertEqual(ordered, report)
+
+    def test_ac12b_order_by_price_margin(self):
+        product = self.product_standard
+        product.standard_price = 100.0
+        low_margin_invoice = self._create_customer_invoice(product, quantity=1, price_unit=150)
+        product.standard_price = 10.0
+        high_margin_invoice = self._create_customer_invoice(product, quantity=1, price_unit=150)
+
+        ordered = self.env["account.invoice.report"].search(
+            [("move_id", "in", (low_margin_invoice | high_margin_invoice).ids)],
+            order="price_margin desc",
+        )
+        self.assertEqual(ordered.mapped("move_id"), (high_margin_invoice | low_margin_invoice))
+
+    def test_ac13_chained_overrides_with_account_ux_and_personalizations(self):
+        # Requires account_ux and personalizations_adhoc installed: if either
+        # of their _select() append columns disappeared, this would error out
+        # reading them, or our own append would have broken the SELECT.
+        installed = self.env["ir.module.module"].search(
+            [
+                ("name", "in", ["account_ux", "personalizations_adhoc"]),
+                ("state", "=", "installed"),
+            ]
+        )
+        if len(installed) < 2:
+            self.skipTest("account_ux and personalizations_adhoc must both be installed")
+
+        product = self.product_standard
+        invoice = self._create_customer_invoice(product, quantity=6)
+        report = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        values = report.read(["total_cc", "discount", "historical_cost", "price_margin", "inventory_value"])[0]
+        self.assertTrue(values)
+
+    def test_ac14_weighted_unit_cost(self):
+        product = self.product_standard
+        product.standard_price = 100.0
+        invoice_1 = self._create_customer_invoice(product, quantity=2)
+        product.standard_price = 50.0
+        invoice_2 = self._create_customer_invoice(product, quantity=8)
+
+        groups = self.env["account.invoice.report"]._read_group(
+            [("move_id", "in", (invoice_1 | invoice_2).ids)],
+            groupby=["product_id"],
+            aggregates=["historical_unit_cost:avg"],
+        )
+        self.assertEqual(len(groups), 1)
+        _, weighted_unit_cost = groups[0]
+        # (2*100 + 8*50) / 10 = 60, not the simple average of 100 and 50 (75).
+        self.assertAlmostEqual(weighted_unit_cost, 60.0)

--- a/account_invoice_historical_cost/views/account_move_line_views.xml
+++ b/account_invoice_historical_cost/views/account_move_line_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_move_line_tree_historical_cost" model="ir.ui.view">
+        <field name="name">account.move.line.list.historical.cost</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="balance" position="after">
+                <field name="historical_cost" optional="hide" groups="base.group_user"/>
+                <field name="historical_cost_provisional" optional="hide" groups="base.group_user"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/account_invoice_historical_cost/views/account_move_views.xml
+++ b/account_invoice_historical_cost/views/account_move_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_move_form_historical_cost" model="ir.ui.view">
+        <field name="name">account.move.form.historical.cost</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']//field[@name='price_total']" position="after">
+                <field name="historical_cost" optional="hide" groups="base.group_user"/>
+                <field name="historical_cost_provisional" optional="hide" groups="base.group_user"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary

`account.invoice.report` recomputes `price_margin`/`inventory_value` against the product's *current* `standard_price`, so changing a product's cost silently changes the margin of already posted invoices. This module freezes the real cost (COGS) on `account.move.line` at posting time and makes the report use it via `COALESCE`, so historical margin analysis stays stable while invoices without the field keep the old dynamic behavior unchanged.

- New fields `historical_cost` / `historical_cost_provisional` on `account.move.line`, frozen in `_post()` (before `stock_account` creates the COGS lines), cleared on `button_draft`/`button_cancel`.
- Hook on `stock.move._action_done` completes provisional lines (invoiced before delivery) once the real stock move is done, reading `stock.move.value` directly to avoid double-counting.
- `account.invoice.report` override (`_select`/`_field_to_sql`/`_read_group_select`) with zero regression for historical invoices via `COALESCE`, plus a derived `historical_unit_cost` measure.
- Opt-in module (`auto_install = False`).

## Test plan

- [x] 21 automated tests covering AC1–AC17 (`odoo-bin -u account_invoice_historical_cost --test-enable --test-tags /account_invoice_historical_cost`), all green.
- [x] `pre-commit` clean.
- [ ] Needs to be added by hand to runbot's "with tests" module whitelist for CI.