### PR TITLE
[FIX] account_internal_transfer: transfer report language fallback

### DIFF
--- a/account_internal_transfer/views/report_account_transfer.xml
+++ b/account_internal_transfer/views/report_account_transfer.xml
@@ -38,7 +38,7 @@
     <template id="report_account_transfer">
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
-                <t t-set="lang" t-value="o.partner_id.lang"/>
+                <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
                 <t t-call="account_internal_transfer.report_account_transfer_document" t-lang="lang"/>
             </t>
         </t>


### PR DESCRIPTION
### Problema

El reporte de transferencia se renderiza sin idioma y los términos traducidos salen en inglés (`Date:`, `- Activities Start:` del header fiscal, cuando el módulo de localización lo agrega).

La plantilla hace:

```xml
<t t-set="lang" t-value="o.partner_id.lang"/>
<t t-call="..." t-lang="lang"/>
```

pero en una transferencia interna `partner_id` es `False` por diseño — `_compute_partner_id` lo fuerza a `False` para los pagos con `is_internal_transfer`. Con `lang` vacío, `t-lang` (alias de `t-options-lang`) termina en `with_context(lang=False)`, y la lectura de campos traducidos cae a `env.lang or 'en_US'`, es decir al término fuente en inglés.

Como el resto del cuerpo del reporte está escrito directamente en castellano, solo se notan los términos que sí pasan por traducción.

### Solución

Fallback al idioma del contacto de la compañía, mismo patrón que ya usa el reporte de recibo de pago en `l10n_ar_tax`:

```xml
<t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
```

### Cómo probar

1. Base con un solo idioma activo distinto de inglés (ej. `es_AR`) y el contacto de la compañía con ese idioma.
2. Crear y confirmar una transferencia interna entre dos diarios de liquidez.
3. Imprimir el reporte de transferencia.
4. Antes: los términos traducibles del header salen en inglés. Después: salen en el idioma de la compañía.

Ticket: https://www.adhoc.inc/odoo/helpdesk/124904