### PR TITLE
[FIX] account_ux: follow background_post rename to a scheduling date

### DIFF
--- a/account_ux/models/account_move.py
+++ b/account_ux/models/account_move.py
@@ -49,10 +49,10 @@ class AccountMove(models.Model):
         """After validate invoice will sent an email to the partner if the related journal has mail_template_id set"""
         # Use action_post to ensure the mail is sent only when the move is posted. The massive
         # confirmation wizard does not go through here, it is handled on validate.account.move
-        # The posting resets background_post, so we take note of the deferred ones beforehand. We
-        # pass them on the context because other modules extend action_send_invoice_mail and
+        # The posting resets background_post_date, so we take note of the deferred ones beforehand.
+        # We pass them on the context because other modules extend action_send_invoice_mail and
         # changing its signature would break them
-        deferred = self.filtered("background_post")
+        deferred = self.filtered("background_post_date")
         res = super().action_post()
         self.with_context(deferred_invoice_mail_ids=deferred.ids).action_send_invoice_mail()
         return res


### PR DESCRIPTION
## What

`account_ux.action_post` takes note of the invoices scheduled for background posting before calling `super()`, so it does not send the journal mail template for them. It did so with `self.filtered("background_post")`.

ingadhoc/account-invoicing#312 replaces that boolean with the `background_post_date` datetime, so the old name raises `KeyError: 'background_post'` on **every** `action_post()` once both are installed — `account_ux` depends on `account_background_post`.

## Changes

- `self.filtered("background_post")` → `self.filtered("background_post_date")`, and the comment above it follows the rename.

Behaviour is unchanged: the field is truthy exactly when the invoice is scheduled, and posting still clears it.

## Test plan

Same runbot batch as the PR that renames the field (same branch name), so the OBA build installs both together. That build is what surfaced this: `account_ux` reported 3 errors of 5 tests, and the same `KeyError` cascaded through ~60 tests in `account_payment_pro`, `l10n_ar_*`, `account_debt_report`, `sale_ux` and others — all of them just calling `action_post()`.

Task: https://www.adhoc.inc/mail/view?model=project.task&res_id=72206
