### PR TITLE
[UPD] account_internal_transfer: bump version to 18.0.1.7.0

### DIFF
--- a/account_internal_transfer/__manifest__.py
+++ b/account_internal_transfer/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Internal Transfer",
-    "version": "18.0.1.6.0",
+    "version": "18.0.1.7.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",


### PR DESCRIPTION
Bump que quedó pendiente del fix del reporte de transferencia (https://github.com/ingadhoc/account-financial-tools/pull/1011): el cambio toca una vista QWeb, que se persiste en `ir.ui.view` y necesita `-u` al desplegar, pero se mergeó sin el flag `bump`.

Solo cambia `version` en el manifest. Mergear con `@roboadhoc nobump` para que el bot no lo vuelva a bumpear.