### PR TITLE
[FIX] account_ux: let a journal creation flow skip the suspense check

### DIFF
--- a/account_ux/models/account_journal.py
+++ b/account_ux/models/account_journal.py
@@ -41,7 +41,15 @@ class AccountJournal(models.Model):
         transitoria siga presente en las líneas, y al conciliar contra un pago cuya
         contrapartida está en esa misma cuenta, la transitoria nunca sale. El botón
         queda gris sin mensaje que lo explique. Bloqueamos la configuración de raíz.
+
+        Se puede saltear pasando ``skip_suspense_outstanding_check`` en el contexto. Es
+        para el módulo que crea un diario en su instalación y arma sus cuentas en varios
+        pasos dentro de la misma transacción: ahí un estado intermedio puede coincidir y
+        haría fallar el install entero, mientras que la configuración final es válida. La
+        edición manual del diario nunca lleva ese contexto, así que sigue validada.
         """
+        if self.env.context.get("skip_suspense_outstanding_check"):
+            return
         for journal in self:
             suspense = journal.suspense_account_id
             if not suspense:

--- a/account_ux/models/account_payment_method_line.py
+++ b/account_ux/models/account_payment_method_line.py
@@ -18,9 +18,18 @@ class AccountPaymentMethodLine(models.Model):
         pero disparado desde el otro lado: al editar la cuenta outstanding del método de
         pago. Si coincide con la transitoria del diario, la conciliación bancaria nunca
         se puede validar (el botón "Validar" queda gris).
+
+        Igual que la del diario, se puede saltear con ``skip_suspense_outstanding_check``
+        en el contexto, para el módulo que crea el diario y sus cuentas en varios pasos
+        dentro de una misma transacción.
         """
+        if self.env.context.get("skip_suspense_outstanding_check"):
+            return
         for line in self:
-            suspense = line.journal_id.suspense_account_id
+            journal = line.journal_id
+            if not journal:
+                continue
+            suspense = journal.suspense_account_id
             if line.payment_account_id and suspense and line.payment_account_id == suspense:
                 raise ValidationError(
                     _(


### PR DESCRIPTION
## What

`account.journal._check_suspense_account_not_outstanding` and
`account.payment.method.line._check_outstanding_account_not_suspense` (added in #981)
reject any journal whose suspense account is also used as an outstanding
receipts/payments account.

Both are validated **inside** `create` / `write` (`models.py` calls `_validate_fields`
there), not at the end of the transaction. So a module that creates a journal and fills
its accounts in several steps within one transaction can trip on an *intermediate* state
that coincides, even when the configuration it ends up with is perfectly valid. When the
journal is created by a `post_init_hook`, that aborts the module installation: `Failed to
load registry`, rollback, module left uninstalled.

Both constraints now return early when `skip_suspense_outstanding_check` is in the
context, so a creation flow can opt out for its own transaction. Everything else is
unchanged — in particular a **manual edit** of the journal or of the payment method line
never carries that context, so the configuration stays validated.

## Test plan

- No behaviour change without the context key: a bank/cash journal with
  suspense == outstanding is still rejected from either side.
- With the key, the write goes through.
- The consumer and the tests covering both directions live in `ingadhoc/account-payment`,
  same branch name, so runbot builds both together.
