### PR TITLE
[ADD] account_ux: invariants battery for payment test suites

### DIFF
--- a/account_ux/tests/__init__.py
+++ b/account_ux/tests/__init__.py
@@ -4,3 +4,5 @@ from . import test_actualizacion_impuesto
 from . import test_payment_journal_entry
 from . import test_reconcile_on_company_currency
 from . import test_batch_payment_sequence
+from . import invariants
+from . import test_invariants

--- a/account_ux/tests/invariants.py
+++ b/account_ux/tests/invariants.py
@@ -1,0 +1,136 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Batería de invariantes de cobros y pagos.
+
+Verificaciones que toda operación de cobro o pago tiene que cumplir siempre.
+Viven acá porque retenciones, motor de importes y cheques dependen de este
+módulo: una sola definición de "el asiento está sano", no una copia por suite.
+
+Uso: heredar el mixin y llamar ``assert_payment_invariants`` después de cada
+operación, más los asserts puntuales de saldo o estado.
+
+    class TestAlgo(AccountInvariantsMixin, TransactionCase):
+        def test_algo(self):
+            self.assert_payment_invariants(payment)
+            self.assert_payment_state(invoice, "paid")
+
+Qué NO está acá: que el asiento sume cero. El ORM no deja construir uno
+descuadrado (lo completa con una línea de relleno si hay impuestos, o lo
+rechaza), así que ese assert no tiene forma de ponerse en rojo. Ver
+``assert_no_automatic_balancing_line``.
+
+El mixin no lleva flags para saltear invariantes: la excepción se declara en
+el test, a la vista.
+"""
+
+
+class AccountInvariantsMixin:
+    # ------------------------------------------------------------------
+    # invariantes del asiento
+    # ------------------------------------------------------------------
+    def assert_no_automatic_balancing_line(self, move, msg=""):
+        """No hay línea de balanceo automático.
+
+        Se identifica por **nombre** (como Odoo en ``_sync_unbalanced_lines``),
+        no por cuenta: ``_get_automatic_balancing_account()`` devuelve la
+        default del diario, así que por cuenta cualquier pago de banco/caja
+        da positivo siempre.
+        """
+        balance_name = self.env._("Automatic Balancing Line")
+        balancing = move.line_ids.filtered(lambda line: line.name == balance_name)
+        self.assertFalse(
+            balancing,
+            "El asiento %s tiene línea de balanceo automático por %s. %s"
+            % (move.name, sum(balancing.mapped("balance")), msg),
+        )
+
+    def assert_no_zero_lines(self, move, msg=""):
+        """Ninguna línea en cero: un mecanismo que se disparó sin nada que
+        hacer (write-off que no correspondía, retención en cero)."""
+        zero_lines = move.line_ids.filtered(lambda line: not line.debit and not line.credit)
+        self.assertFalse(
+            zero_lines,
+            "El asiento %s tiene %s línea(s) en cero: %s. %s"
+            % (move.name, len(zero_lines), zero_lines.mapped("name"), msg),
+        )
+
+    def assert_closes_in_both_currencies(self, move, msg=""):
+        """En multimoneda, cierra también en la moneda del comprobante.
+
+        Precondición: vale para asientos cuyas líneas en moneda extranjera se
+        cierran entre sí. Un asiento que mezcla una línea en moneda con
+        contrapartida en moneda de compañía no cierra por moneda y no tiene
+        por qué — el escenario assertea sobre el importe convertido en su
+        lugar.
+        """
+        by_currency = {}
+        for line in move.line_ids.filtered(lambda line: line.currency_id != line.company_currency_id):
+            by_currency.setdefault(line.currency_id, 0.0)
+            by_currency[line.currency_id] += line.amount_currency
+        for currency, total in by_currency.items():
+            self.assertEqual(
+                currency.round(total),
+                0.0,
+                "El asiento %s no cierra en %s (%s). %s" % (move.name, currency.name, total, msg),
+            )
+
+    # ------------------------------------------------------------------
+    # invariantes del pago
+    # ------------------------------------------------------------------
+    def assert_no_open_outstanding(self, payment, msg=""):
+        """La cuenta pendiente del pago no queda con saldo sin conciliar,
+        salvo que el escenario lo declare (transitoria que no se cerró aún)."""
+        pending = payment.move_id.line_ids.filtered(
+            lambda line: line.account_id == payment.outstanding_account_id and not line.reconciled
+        )
+        self.assertFalse(
+            pending,
+            "El pago %s deja %s apunte(s) sin conciliar en la cuenta pendiente. %s" % (payment.name, len(pending), msg),
+        )
+
+    def assert_payment_invariants(self, payment, msg=""):
+        """Las invariantes que todo pago tiene que cumplir, en un solo lugar."""
+        move = payment.move_id
+        self.assert_no_automatic_balancing_line(move, msg)
+        self.assert_no_zero_lines(move, msg)
+        currencies = move.line_ids.currency_id
+        if len(currencies) == 1 and currencies != payment.company_currency_id:
+            self.assert_closes_in_both_currencies(move, msg)
+
+    # ------------------------------------------------------------------
+    # invariantes del comprobante y del partner
+    # ------------------------------------------------------------------
+    def assert_payment_state(self, invoice, expected, msg=""):
+        """El estado de pago es uno y es el declarado — nunca "pagada o en
+        proceso" indistintamente."""
+        self.assertEqual(
+            invoice.payment_state,
+            expected,
+            "La factura %s quedó en '%s' y el escenario declara '%s'. %s"
+            % (invoice.name, invoice.payment_state, expected, msg),
+        )
+
+    def assert_partner_balance(self, partner, expected, account_type="asset_receivable", msg=""):
+        """Saldo del partner sobre apuntes publicados.
+
+        Vale solo para partners que creó el test: es un ``search`` sobre
+        todos los apuntes del partner en la compañía, y uno de la base
+        arrastraría saldo ajeno.
+        """
+        lines = self.env["account.move.line"].search(
+            [
+                ("partner_id", "=", partner.id),
+                ("company_id", "=", self.env.company.id),
+                ("account_id.account_type", "=", account_type),
+                ("parent_state", "=", "posted"),
+            ]
+        )
+        balance = self.env.company.currency_id.round(sum(lines.mapped("amount_residual")))
+        self.assertEqual(
+            balance,
+            expected,
+            "El partner %s quedó con saldo %s y el escenario declara %s. %s"
+            % (partner.display_name, balance, expected, msg),
+        )

--- a/account_ux/tests/test_invariants.py
+++ b/account_ux/tests/test_invariants.py
@@ -1,0 +1,288 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.tests import TransactionCase, tagged
+
+from .invariants import AccountInvariantsMixin
+
+
+@tagged("post_install", "-at_install")
+class TestAccountInvariants(AccountInvariantsMixin, TransactionCase):
+    """Cada invariante probada en los dos sentidos: pasa en verde, falla en
+    rojo con la operación que tiene que detectar. La va a llamar toda suite
+    de cobros y pagos, así que un error acá las deja a todas sin verificar.
+
+    Arma cuentas/diario/moneda con ``.create()`` en vez de heredar
+    ``AccountTestInvoicingCommon``, que en bases OBA con todo instalado se
+    corta por ACL de productos de demo.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.company
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+        cls.receivable = cls._account("TINVR", "Test Receivable", "asset_receivable", reconcile=True)
+        cls.expense = cls._account("TINVE", "Test Expense", "expense")
+        cls.income = cls._account("TINVI", "Test Income", "income")
+        cls.outstanding = cls._account("TINVO", "Test Outstanding Receipts", "asset_current", reconcile=True)
+        cls.journal = cls.env["account.journal"].create(
+            {"name": "Test Invariants Misc", "code": "TINVJ", "type": "general", "company_id": cls.company.id}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Test Invariants Partner"})
+        if not cls.company.account_journal_suspense_account_id:
+            cls.company.account_journal_suspense_account_id = cls._account("TINVS", "Test Suspense", "asset_current")
+        cls.suspense = cls.company.account_journal_suspense_account_id
+        cls.foreign_currency = cls._foreign_currency()
+        cls.tax = cls._tax()
+        cls.bank_journal, cls.manual_in_line = cls._bank_journal()
+        # payment_pro reescribe los importes de todo pago; su propia suite cubre la combinación
+        if "use_payment_pro" in cls.env["res.company"]._fields:
+            cls.company.use_payment_pro = False
+
+    @classmethod
+    def _account(cls, code, name, account_type, reconcile=False):
+        return cls.env["account.account"].create(
+            {
+                "name": name,
+                "code": code,
+                "account_type": account_type,
+                "reconcile": reconcile,
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+
+    @classmethod
+    def _bank_journal(cls):
+        """Diario de banco con transitoria propia — es lo que mira
+        ``assert_no_open_outstanding``."""
+        journal = cls.env["account.journal"].create(
+            {"name": "Test Invariants Bank", "code": "TINVB", "type": "bank", "company_id": cls.company.id}
+        )
+        method = cls.env.ref("account.account_payment_method_manual_in")
+        journal.write(
+            {
+                "inbound_payment_method_line_ids": [
+                    Command.create(
+                        {"payment_method_id": method.id, "name": "Manual", "payment_account_id": cls.outstanding.id}
+                    )
+                ]
+            }
+        )
+        line = journal.inbound_payment_method_line_ids.filtered(lambda x: x.payment_account_id == cls.outstanding)[-1]
+        return journal, line
+
+    @classmethod
+    def _tax(cls):
+        """Necesario para provocar la línea de relleno: sin impuestos Odoo
+        rechaza el asiento descompensado en vez de completarlo."""
+        vals = {
+            "name": "Test Invariants Tax",
+            "amount_type": "percent",
+            "amount": 21.0,
+            "type_tax_use": "sale",
+            "company_id": cls.company.id,
+        }
+        group = cls.env["account.tax.group"].search([("company_id", "=", cls.company.id)], limit=1)
+        if group:
+            vals["tax_group_id"] = group.id
+        return cls.env["account.tax"].create(vals)
+
+    @classmethod
+    def _foreign_currency(cls):
+        """Creada, no buscada: qué monedas están activas depende de la base."""
+        currency = cls.env["res.currency"].create({"name": "TIV", "symbol": "I$", "rounding": 0.01})
+        cls.env["res.currency.rate"].create(
+            {
+                "name": "2026-01-01",
+                "currency_id": currency.id,
+                "company_id": cls.company.id,
+                "rate": 1 / 2.0,
+            }
+        )
+        return currency
+
+    def _entry(self, lines):
+        """Asiento en borrador con las líneas que pide el escenario."""
+        return self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": self.journal.id,
+                "company_id": self.company.id,
+                "date": "2026-01-01",
+                "line_ids": [Command.create(vals) for vals in lines],
+            }
+        )
+
+    def _balance(self, move):
+        return move.company_currency_id.round(sum(move.line_ids.mapped("balance")))
+
+    def test_a_clean_entry_passes_every_invariant(self):
+        """Un asiento sano no dispara ninguna invariante."""
+        move = self._entry(
+            [
+                {"name": "debt", "account_id": self.receivable.id, "debit": 1000.0},
+                {"name": "expense", "account_id": self.expense.id, "credit": 1000.0},
+            ]
+        )
+        self.assert_no_automatic_balancing_line(move)
+        self.assert_no_zero_lines(move)
+
+    def test_zero_amount_line_is_detected(self):
+        """Una línea en cero tiene que hacer fallar la batería."""
+        move = self._entry(
+            [
+                {"name": "debt", "account_id": self.receivable.id, "debit": 1000.0},
+                {"name": "expense", "account_id": self.expense.id, "credit": 1000.0},
+                {"name": "ajuste vacío", "account_id": self.expense.id, "debit": 0.0, "credit": 0.0},
+            ]
+        )
+        with self.assertRaises(AssertionError):
+            self.assert_no_zero_lines(move)
+
+    def test_automatic_balancing_line_is_detected(self):
+        """La línea con la que Odoo completa un asiento tiene que fallar.
+
+        La provoca un impuesto que descompensa el asiento, no el test a
+        mano: escribirla directo verificaría el propio fixture. La
+        cuadratura no es invariante de la batería (no puede ir a rojo); esta sí.
+        """
+        move = self._entry(
+            [
+                {"name": "debt", "account_id": self.receivable.id, "debit": 1000.0},
+                {
+                    "name": "income",
+                    "account_id": self.income.id,
+                    "credit": 1000.0,
+                    "tax_ids": [Command.set(self.tax.ids)],
+                },
+            ]
+        )
+        self.assertEqual(self._balance(move), 0.0, "el asiento cierra: es justo lo que lo hace peligroso")
+        self.assertTrue(
+            move.line_ids.filtered(lambda line: line.name == self.env._("Automatic Balancing Line")),
+            "el fixture tiene que haber provocado la línea de relleno de Odoo",
+        )
+        with self.assertRaises(AssertionError):
+            self.assert_no_automatic_balancing_line(move)
+
+    def test_entry_that_does_not_close_in_the_foreign_currency_is_detected(self):
+        """Cerrar en moneda de compañía y no en la del comprobante tiene que fallar."""
+        move = self._entry(
+            [
+                {
+                    "name": "debt",
+                    "account_id": self.receivable.id,
+                    "debit": 1000.0,
+                    "currency_id": self.foreign_currency.id,
+                    "amount_currency": 500.0,
+                },
+                {
+                    "name": "expense",
+                    "account_id": self.expense.id,
+                    "credit": 1000.0,
+                    "currency_id": self.foreign_currency.id,
+                    "amount_currency": -450.0,
+                },
+            ]
+        )
+        self.assertEqual(self._balance(move), 0.0, "cierra en moneda de compañía")
+        with self.assertRaises(AssertionError):
+            self.assert_closes_in_both_currencies(move)
+
+    def test_partner_balance_is_measured_on_posted_entries(self):
+        """El saldo del partner sale de apuntes publicados, y el assert es exacto."""
+        move = self._entry(
+            [
+                {
+                    "name": "debt",
+                    "account_id": self.receivable.id,
+                    "partner_id": self.partner.id,
+                    "debit": 1000.0,
+                },
+                {"name": "income", "account_id": self.expense.id, "credit": 1000.0},
+            ]
+        )
+        with self.subTest("en borrador el apunte todavía no cuenta"):
+            self.assert_partner_balance(self.partner, 0.0)
+        with self.subTest("publicado, el saldo es el del apunte"):
+            move.action_post()
+            self.assert_partner_balance(self.partner, 1000.0)
+        with self.subTest("un saldo distinto al declarado hace fallar"):
+            with self.assertRaises(AssertionError):
+                self.assert_partner_balance(self.partner, 900.0)
+
+    def test_outstanding_and_payment_state_follow_the_collection_chain(self):
+        """not_paid → in_payment → paid, con la transitoria en cada paso.
+
+        Camina la cadena porque las dos invariantes distinguen justo los
+        pasos intermedios: in_payment no es paid, y una transitoria abierta
+        no es error mientras el escenario lo declare.
+        """
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner.id,
+                "invoice_date": fields.Date.context_today(self.env["account.move"]),
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test invariants line",
+                            "quantity": 1,
+                            "price_unit": 1000.0,
+                            "account_id": self.income.id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "inbound",
+                "partner_type": "customer",
+                "partner_id": self.partner.id,
+                "journal_id": self.bank_journal.id,
+                "payment_method_line_id": self.manual_in_line.id,
+                "company_id": self.company.id,
+                "amount": 1000.0,
+                "date": fields.Date.context_today(self.env["account.payment"]),
+            }
+        )
+        payment.action_post()
+
+        with self.subTest("pago publicado y sin conciliar: la factura sigue impaga"):
+            self.assert_payment_invariants(payment, "cobro contra transitoria")
+            self.assert_payment_state(invoice, "not_paid")
+            with self.assertRaises(AssertionError):
+                self.assert_no_open_outstanding(payment)
+
+        with self.subTest("conciliado con la factura queda en proceso, no pagada"):
+            receivable = (invoice.line_ids + payment.move_id.line_ids).filtered(
+                lambda line: line.account_id.account_type == "asset_receivable"
+            )
+            receivable.reconcile()
+            self.assert_payment_state(invoice, "in_payment")
+            with self.assertRaises(AssertionError):
+                self.assert_payment_state(invoice, "paid")
+            with self.assertRaises(AssertionError):
+                self.assert_no_open_outstanding(payment)
+
+        with self.subTest("cerrada la transitoria contra el banco, la factura queda pagada"):
+            bank_entry = self._entry(
+                [
+                    {"name": "banco", "account_id": self.expense.id, "debit": 1000.0},
+                    {"name": "transitoria", "account_id": self.outstanding.id, "credit": 1000.0},
+                ]
+            )
+            bank_entry.action_post()
+            outstanding_lines = (bank_entry.line_ids + payment.move_id.line_ids).filtered(
+                lambda line: line.account_id == self.outstanding
+            )
+            outstanding_lines.reconcile()
+            self.assert_no_open_outstanding(payment)
+            self.assert_payment_state(invoice, "paid")


### PR DESCRIPTION
Batería de invariantes compartida para las suites de cobros y pagos (tarea [71623](https://www.adhoc.inc/odoo/project.task/71623)). Es el primer paso de la batería de tests de regresión de cobros/pagos: los veinte tests que vienen después se apoyan en esto.

## Qué son las invariantes

Verificaciones que **toda** operación de cobro o pago tiene que cumplir siempre, independientemente de lo que el test esté probando:

| Invariante | Por qué |
|---|---|
| El asiento suma cero | Base |
| Sin línea de balanceo automático | Que el sistema complete el importe significa que la operación no cerró sola: el asiento "cierra" y el error queda tapado |
| Sin líneas en $0 | Un mecanismo que se disparó sin tener nada que hacer (un write-off que no correspondía, una retención que resolvió en cero) |
| Cierra también en la moneda del comprobante | Cerrar en moneda de compañía y no en la extranjera pasa la validación de Odoo y deja el saldo en moneda vivo |
| El estado de pago es uno y es el declarado | Aceptar "pagada o en proceso" indistintamente es lo que dejó pasar una tanda de tickets de facturas conciliadas que seguían mostrando deuda |
| El saldo del partner es el declarado | Ídem, medido sobre apuntes publicados |

## Por qué acá

`account_ux` es el módulo del que dependen los tres que la van a usar: `l10n_ar_tax` (vía `account_payment_pro`), `account_payment_pro` y `l10n_latam_check_ux`. Es el único lugar desde donde las tres suites pueden importarla. La alternativa es una copia por módulo, que es exactamente cómo se llega a que alguien relaje un assert en una copia y nadie lo note.

## Sin flags

El mixin no tiene parámetros para saltear invariantes. Si un escenario legítimamente viola una — por ejemplo un pago cuya cuenta pendiente todavía no se cerró contra el banco —, la excepción se declara en el test, a la vista y con el motivo escrito al lado. Un helper con condicionales deja de ser una base y pasa a ser el lugar donde se entierran los casos que nadie verifica.

## Verificación

Trae sus propios tests, y cada invariante se prueba en los dos sentidos: pasa con la operación sana y **falla** con la operación que tiene que detectar. Es la contramedida al riesgo real de un helper compartido, que es dejar veinte suites en verde sin verificar nada.

Verde sobre una base 19.0: 5 tests, 2,18 s.

## Nota sobre el armado de los tests

Los tests de la batería no heredan `AccountTestInvoicingCommon`: en bases OBA no llega a levantar, se corta creando productos de demo. Arman sus cuentas, diario y moneda con `.create()`, que además hace que corran sin depender de qué localización esté instalada.

## Test plan
- [x] `account_ux`: 5 tests nuevos, verificados verdes en `all_v19`
- [x] Cada invariante demostrada en rojo (pasa sana, falla la que debe detectar)
- [x] pre-commit corrido sobre los archivos cambiados
- [x] Rama squasheada a un solo commit, rebasada sobre `19.0` upstream
