### PR TITLE
[FIX] account_journal_security: restore journal filtering by allowed users

### DIFF
--- a/account_journal_security/models/account_journal.py
+++ b/account_journal_security/models/account_journal.py
@@ -117,47 +117,48 @@ class AccountJournal(models.Model):
         user = self.env.user
         # Agregamos el with_user ya que por alguna razon llega con sudo y nos da un falso positivo indicando
         # que el usuario es super usuario. De esta forma nos aseguramos verdaderamente si lo es.
-        self.env.cr.execute(
-            """
-                SELECT journal_id
-                FROM journal_security_journal_modification_users
-                WHERE user_id != %s
-            """,
-            (user.id,),
-        )
-        modification_journal_ids = [r[0] for r in self.env.cr.fetchall()]
-        self.env.cr.execute(
-            """
-                SELECT journal_id
-                FROM journal_security_journal_users
-                WHERE user_id != %s
-            """,
-            (user.id,),
-        )
-        self.env.cr.execute(
-            """
-                SELECT journal_id
-                FROM journal_security_journal_users
-                WHERE user_id = %s
-            """,
-            (user.id,),
-        )
-        user_journal_ids = [r[0] for r in self.env.cr.fetchall()]
-        restric_user_journal_ids = [r[0] for r in self.env.cr.fetchall()]
-        journal_ids = restric_user_journal_ids + modification_journal_ids
-        if not self.with_user(user.id).env.is_superuser() and not self.env.context.get("journal_security", False):
-            domain += ["|", ("user_ids", "=", False), ("id", "in", user_journal_ids)]
-        if not self.with_user(user.id).env.is_superuser() and self.env.context.get("journal_security", False):
-            domain += ["|", ("modification_user_ids", "=", False), ("id", "not in", journal_ids)]
-        if limit == 1 and not self.with_user(user.id).env.is_superuser():
-            # Agregamos el domain de los journals donde el usuario tiene permisos
-            domain += [
-                "|",
-                "&",
-                ("user_ids", "=", False),
-                ("modification_user_ids", "=", False),
-                ("id", "not in", journal_ids),
-            ]
+        if not self.with_user(user.id).env.is_superuser():
+            # Traemos los diarios donde el usuario ESTA habilitado. Lo consultamos por SQL sobre las tablas
+            # de relacion (en vez de user.journal_ids / user.modification_journal_ids) para no depender de
+            # las ir.rules de account.journal al resolver los m2m del usuario.
+            self.env.cr.execute(
+                """
+                    SELECT journal_id
+                    FROM journal_security_journal_modification_users
+                    WHERE user_id = %s
+                """,
+                (user.id,),
+            )
+            # modification allowed journals. the other users can only see the journal items but not write or create
+            user_modification_journal_ids = [r[0] for r in self.env.cr.fetchall()]
+            self.env.cr.execute(
+                """
+                    SELECT journal_id
+                    FROM journal_security_journal_users
+                    WHERE user_id = %s
+                """,
+                (user.id,),
+            )
+            # totally allowed journals. the other users can not see the journal items and cannot write or create
+            user_journal_ids = [r[0] for r in self.env.cr.fetchall()]
+            # journals where the user is allowed to write or create
+            journal_ids = user_journal_ids + user_modification_journal_ids
+            # Aca es para el search del compute available journals
+            if self.env.context.get("journal_security", False):
+                # Diarios sin restriccion de modificacion o donde el usuario esta habilitado a modificar
+                domain += ["|", ("modification_user_ids", "=", False), ("id", "in", user_modification_journal_ids)]
+                # Diarios sin restriccion total o donde el usuario esta habilitado
+                domain += ["|", ("user_ids", "=", False), ("id", "in", user_journal_ids)]
+            # aca es para cuando se hace el create que toma un primer diario que encuentra.
+            if limit == 1:
+                # Agregamos el domain de los journals donde el usuario tiene permisos
+                domain += [
+                    "|",
+                    "&",
+                    ("user_ids", "=", False),
+                    ("modification_user_ids", "=", False),
+                    ("id", "in", journal_ids),
+                ]
         return super()._search(domain, offset, limit, order, **kwargs)
 
     @api.onchange("journal_restriction")

--- a/account_journal_security/models/account_payment.py
+++ b/account_journal_security/models/account_payment.py
@@ -5,4 +5,4 @@ class AccountPayment(models.Model):
     _inherit = "account.payment"
 
     def _compute_available_journal_ids(self):
-        super(AccountPayment, self.with_context(journal_security=True))._compute_available_journal_ids()
+        super(AccountPayment, self.sudo(False).with_context(journal_security=True))._compute_available_journal_ids()

--- a/account_journal_security/tests/test_account_journal_security.py
+++ b/account_journal_security/tests/test_account_journal_security.py
@@ -17,6 +17,60 @@ class TestAccountJournalSecurity(common.TransactionCase):
         account_user_group = self.env.ref("account.group_account_user")
         self.user_demo.write({"group_ids": [(6, 0, [account_user_group.id])]})
 
+    def _create_account_user(self, login):
+        return self.env["res.users"].create(
+            {
+                "name": login,
+                "login": login,
+                "company_id": self.first_company.id,
+                "company_ids": [(6, 0, [self.first_company.id])],
+                "group_ids": [(4, self.env.ref("account.group_account_user").id)],
+            }
+        )
+
+    def _search_journal_for_payment(self, user):
+        """Busca el diario tal como lo hace el selector de diarios de un pago/recibo."""
+        return (
+            self.env["account.journal"]
+            .with_user(user)
+            .with_company(self.first_company)
+            .with_context(journal_security=True)
+            .search([("id", "=", self.company_bank_journal.id)])
+        )
+
+    def test_journal_security_varios_usuarios_habilitados(self):
+        """Con DOS o mas usuarios habilitados a modificar un diario, cada uno de ellos
+        debe seguir viendo ese diario al crear una OP o un recibo, y el resto no.
+
+        Regresion del port a 19.0 (ticket 125244): el filtro traia los diarios donde
+        habia CUALQUIER OTRO usuario habilitado y los excluia, con lo cual sobrevivian
+        solo los diarios sin restriccion o con un unico usuario habilitado.
+        """
+        user_allowed_1 = self._create_account_user("journal_security_allowed_1")
+        user_allowed_2 = self._create_account_user("journal_security_allowed_2")
+        user_restricted = self._create_account_user("journal_security_restricted")
+
+        self.company_bank_journal.write(
+            {
+                "journal_restriction": "modification",
+                "modification_user_ids": [(6, 0, [user_allowed_1.id, user_allowed_2.id])],
+            }
+        )
+
+        for user in (user_allowed_1, user_allowed_2):
+            self.assertIn(
+                self.company_bank_journal,
+                self._search_journal_for_payment(user),
+                "Un usuario habilitado a modificar el diario no lo ve al registrar un pago "
+                "cuando hay mas de un usuario habilitado",
+            )
+
+        self.assertNotIn(
+            self.company_bank_journal,
+            self._search_journal_for_payment(user_restricted),
+            "Un usuario NO habilitado ve un diario restringido al registrar un pago",
+        )
+
     def test_journal_security_1(self):
         self.company_bank_journal.write(
             {"journal_restriction": "modification", "modification_user_ids": [(4, self.user_admin.id)]}


### PR DESCRIPTION
## Problem

`AccountJournal._search` was rewritten during the 19.0 migration and the modification restriction ended up inverted. In the `journal_security=True` branch (used by `account.payment._compute_available_journal_ids` and by the payment register wizard) it selected every journal that has any **other** user in "Modifications allowed to" — even when the current user is allowed on it too — and excluded them with `("id", "not in", journal_ids)`.

The result: a journal disappears from the journal selection of payments and receipts as soon as a **second** user is allowed on it. Only journals with no restriction at all, or with the current user as the only allowed user, survive. Users explicitly allowed on a journal are degraded to the level of users that were never allowed.

18.0 (`18.0.1.2.0`) filters the other way around — "no restriction **or** where I am allowed" — so this is a regression of the port, not a behaviour change.

There is a second bug in the same block: three `cr.execute` calls with only two `fetchall`, so `restric_user_journal_ids` reads an already consumed cursor and is always empty. The totally restricted journals therefore never took part in the filter.

## Fix

- Query the relation tables for the journals the current user **is** allowed on (`WHERE user_id = %s`) and filter them with `in`, restoring the 18.0 semantics.
- One `fetchall` per `execute`.
- The whole block now runs inside a single superuser check, and the context branch is an `if/else` instead of two `if` with the same repeated condition.

No migration script, no view or data changes, so the manifest is untouched (`nobump`).

## Test plan

New test `test_journal_security_varios_usuarios_habilitados`: two users allowed to modify the same journal must both see it when registering a payment, and a third, not allowed, must not. Users are created with `.create()`, no demo data involved.

Verified on a clean 19.0 database:

- Without the fix: `1 failed, 0 error(s) of 3 tests` — only the new test fails, with `account.journal(6,) not found in account.journal()`. The two pre-existing tests pass, since both use a single allowed user per journal and never reach the broken path.
- With the fix: `0 failed, 0 error(s) of 3 tests`.

Reported in ticket https://www.adhoc.inc/odoo/helpdesk.ticket/125244.