### PR TITLE
[FIX] stock_account_ux: timezone-proof report date and wizard test

### DIFF
--- a/stock_account_ux/static/src/stock_valuation_report/controller_patch.js
+++ b/stock_account_ux/static/src/stock_valuation_report/controller_patch.js
@@ -26,13 +26,20 @@ patch(StockValuationReportController.prototype, {
         return state;
     },
 
+    // "Hoy = sin corte" lo decide el cliente, único lugar con un solo reloj: el server lo
+    // comparaba contra el tz del usuario y adentro del offset no coinciden (ticket 126535).
+    get reportDate() {
+        const date = serializeDate(this.state.date);
+        return date === serializeDate(DateTime.now()) ? false : date;
+    },
+
     // Reimplementación de loadReportData (copia de stock_account v19.0) para
     // sumar los filtros como kwargs del get_report_values. La preparación de
     // líneas es idéntica a la nativa.
     async loadReportData() {
         const state = this._valuationFilterState();
         const kwargs = {
-            date: this.state.date.toISODate() || false,
+            date: this.reportDate,
             product_ids: state.productIds,
             categ_ids: state.categIds,
             cost_methods: state.costMethods,
@@ -153,7 +160,7 @@ patch(StockValuationReportController.prototype, {
         const action = await this.orm.call(
             "stock_account.stock.valuation.report",
             method,
-            [accountId, this.state.date.toISODate() || false],
+            [accountId, this.reportDate],
             {
                 filters: {
                     product_ids: state.productIds,

--- a/stock_account_ux/tests/test_manual_move_valuation.py
+++ b/stock_account_ux/tests/test_manual_move_valuation.py
@@ -1,4 +1,4 @@
-from odoo import Command
+from odoo import Command, fields
 from odoo.addons.stock_account.tests.common import TestStockValuationCommon
 from odoo.exceptions import UserError
 from odoo.tests import tagged
@@ -45,7 +45,9 @@ class TestManualMoveValuation(TestStockValuationCommon):
     def test_draft_defaults(self):
         wizard = self._wizard(self.move_avco)
         self.assertEqual(wizard.journal_id, self.company.account_stock_journal_id)
-        self.assertEqual(wizard.date, self.env.cr.now().date())
+        # Same source the default reads: asserting against ``cr.now()`` compared the user's
+        # timezone with a UTC clock, one day apart inside the offset window (ticket 126535).
+        self.assertEqual(wizard.date, fields.Date.context_today(wizard))
 
     def test_outgoing_move_subtracts(self):
         out_move = self._make_out_move(self.product_avco, 1)


### PR DESCRIPTION
- controller_patch.js: add the ``reportDate`` getter, which resolves "today = no cut-off" against the CLIENT clock, the same criterion ``actionGenerateEntry`` already used. Used in ``loadReportData`` and ``_openVariationDetail``, the two calls whose date reaches domains over Datetime fields. Deciding it server side compared the browser clock with the user's timezone: inside the offset window they differ by a day, the date became a real cut-off and, ``stock.move.date`` being a Datetime, it truncated at 00:00 and dropped the whole day.
- test_manual_move_valuation: ``test_draft_defaults`` asserts against ``fields.Date.context_today(wizard)``, the source the wizard default reads, instead of ``cr.now()``, which is the database's UTC clock.

Change note: Se corrigió el Reporte de Valuación de Inventario, que en ciertos horarios dejaba de mostrar los movimientos del día: la sección de Variación quedaba sin detalle y no aparecía el menú para abrir los movimientos sin contabilizar. Pasaba cuando la zona horaria del usuario y la de su computadora no coincidían en la fecha, algo habitual a última hora del día. Ahora la fecha del reporte se resuelve de un solo lado y el día en curso se muestra completo.