### PR TITLE
[UPD] stock_account_ux: bump version to 19.0.1.3.0

### DIFF
--- a/stock_account_ux/__manifest__.py
+++ b/stock_account_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Stock Move UX",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Warehouse Management",
     "author": "ADHOC SA",
     "website": "https://www.adhoc.com.ar",


### PR DESCRIPTION
Bump que quedó pendiente del PR #984: ese cambio agrega campos nuevos en `product.value` (`previous_value`, `account_move_id`), modelos y vistas nuevas, así que necesita `-u` al desplegar. Se pidió `bump` al mergear pero el bot no lo aplicó, y las bases quedaron con el código nuevo y el esquema viejo: crear un producto con costo distinto de cero rompe con `UndefinedColumn: column "previous_value" of relation "product_value" does not exist`.

Solo cambia `version` en el manifest. Mergear con `@roboadhoc nobump` para que el bot no lo vuelva a bumpear.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/126793
