### PR TITLE
[FIX] account_ux: filtro Producto lento en Análisis de facturas

### DIFF
--- a/account_ux/reports/account_invoice_report_view.xml
+++ b/account_ux/reports/account_invoice_report_view.xml
@@ -30,6 +30,10 @@
         <field name="model">account.invoice.report</field>
         <field name="inherit_id" ref="account.view_account_invoice_report_search"/>
         <field name="arch" type="xml">
+            <field name="product_id" position="attributes">
+                <!-- avoid default ilike on display_name, slow on large catalogs -->
+                <attribute name="filter_domain">['|', ('product_id.default_code', 'ilike', self), ('product_id.name', 'ilike', self)]</attribute>
+            </field>
             <filter name='user' position="after">
                 <filter string="Journal Entry" name="groupby_move_id" context="{'group_by':'move_id'}"/>
                 <filter string="Invoice Currency" name="groupby_currency_id" context="{'group_by':'currency_id'}"/>


### PR DESCRIPTION
## Qué arregla

El filtro "Producto" de la búsqueda de Análisis de facturas (`account.invoice.report`) no tenía `filter_domain`, así que Odoo aplicaba el default `ilike` sobre el `display_name` del producto (código + nombre concatenados), que dispara `_search_display_name` con un `UNION ALL` de dos subqueries. En catálogos grandes es lento.

## Cómo lo arregla

Agrega `filter_domain` explícito sobre `product_id.default_code` (Referencia Interna) OR `product_id.name`, evitando ese camino.

## Test plan

- [ ] Buscar por Referencia Interna en Análisis de facturas y confirmar que filtra bien
- [ ] Buscar por nombre de producto y confirmar que sigue funcionando
- [ ] Comparar tiempos de respuesta en una base con catálogo grande (medición pendiente del lado del reporter)