### PR TITLE
[FIX] account_ux: speed up product filter in invoice analysis search

### DIFF
--- a/account_ux/reports/account_invoice_report_view.xml
+++ b/account_ux/reports/account_invoice_report_view.xml
@@ -30,6 +30,10 @@
         <field name="model">account.invoice.report</field>
         <field name="inherit_id" ref="account.view_account_invoice_report_search"/>
         <field name="arch" type="xml">
+            <field name="product_id" position="attributes">
+                <!-- avoid default ilike on display_name, slow on large catalogs -->
+                <attribute name="filter_domain">['|', ('product_id.default_code', 'ilike', self), ('product_id.name', 'ilike', self)]</attribute>
+            </field>
             <filter name='user' position="after">
                 <filter string="Journal Entry" name="groupby_move_id" context="{'group_by':'move_id'}"/>
                 <filter string="Invoice Currency" name="groupby_currency_id" context="{'group_by':'currency_id'}"/>


### PR DESCRIPTION
## Summary
- Avoid the default `ilike` on `display_name` for the product filter in the invoice analysis search view — slow on large catalogs.
- Filters explicitly by `default_code` or `product name` instead.

task 73452